### PR TITLE
Adding the Geodata_DGM Ontology

### DIFF
--- a/Geodata_DGM/Geodata_DGM_ontology.ttl
+++ b/Geodata_DGM/Geodata_DGM_ontology.ttl
@@ -1,4 +1,4 @@
-@prefix Geodata_DGM: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Geodata_DGM_ontology/> .
+@prefix Geodata_DGM: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/tools/ontologie_creator/ontologies/Geodata_DGM_ontology/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix gax-core: <https://w3id.org/gaia-x/core#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -10,7 +10,7 @@ Geodata_DGM: a owl:Ontology ;
     dcterms:contributor "Maximilian Sindram (VCS)" ;
     owl:versionInfo "0.1"^^xsd:float .
 
-Geodata_DGM:Geodata_DGM a owl:Class ;
+Geodata_DGM:Asset a owl:Class ;
     rdfs:label "Geodata_DGM" ;
     rdfs:comment "attributes for DGM"@en ;
     rdfs:subClassOf gax-core:Resource .

--- a/Geodata_DGM/Geodata_DGM_ontology.ttl
+++ b/Geodata_DGM/Geodata_DGM_ontology.ttl
@@ -1,0 +1,17 @@
+@prefix Geodata_DGM: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Geodata_DGM_ontology/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix gax-core: <https://w3id.org/gaia-x/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+Geodata_DGM: a owl:Ontology ;
+    rdfs:label "ontology definition for Geodata_DGM"@en ;
+    dcterms:contributor "Maximilian Sindram (VCS)" ;
+    owl:versionInfo "0.1"^^xsd:float .
+
+Geodata_DGM:Geodata_DGM a owl:Class ;
+    rdfs:label "Geodata_DGM" ;
+    rdfs:comment "attributes for DGM"@en ;
+    rdfs:subClassOf gax-core:Resource .
+

--- a/Geodata_DGM/Geodata_DGM_shacl.ttl
+++ b/Geodata_DGM/Geodata_DGM_shacl.ttl
@@ -1,4 +1,4 @@
-@prefix Geodata_DGM: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Geodata_DGM_ontology> .
+@prefix Geodata_DGM: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/tools/ontologie_creator/ontologies/Geodata_DGM_ontology/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -11,13 +11,13 @@ Geodata_DGM:Asset_Shape a sh:NodeShape ;
             sh:minCount "0"^^xsd:unsignedInt ;
             sh:name "format"@en ;
             sh:path Geodata_DGM:Geodata_DGM_quality_format ],
-        [ skos:example "2011-11-11 00:00:00" ;
-            sh:datatype xsd:string ;
-            sh:description "Creation Date"@en ;
-            sh:message "Validation of creationDate failed!"@en ;
+        [ skos:example "LDBV Commercial" ;
+            sh:datatype xsd:anyURI ;
+            sh:description "License"@en ;
+            sh:message "Validation of license failed!"@en ;
             sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "creationDate"@en ;
-            sh:path Geodata_DGM:Geodata_DGM_quality_creationDate ],
+            sh:name "license"@en ;
+            sh:path Geodata_DGM:Geodata_DGM_quality_license ],
         [ skos:example "1" ;
             sh:datatype xsd:int ;
             sh:description "Resolution of the dataset"@en ;
@@ -25,12 +25,12 @@ Geodata_DGM:Asset_Shape a sh:NodeShape ;
             sh:minCount "0"^^xsd:unsignedInt ;
             sh:name "resolution"@en ;
             sh:path Geodata_DGM:Geodata_DGM_quality_resolution ],
-        [ skos:example "LDBV Commercial" ;
-            sh:datatype xsd:anyURI ;
-            sh:description "License"@en ;
-            sh:message "Validation of license failed!"@en ;
+        [ skos:example "2011-11-11 00:00:00" ;
+            sh:datatype xsd:string ;
+            sh:description "Creation Date"@en ;
+            sh:message "Validation of creationDate failed!"@en ;
             sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "license"@en ;
-            sh:path Geodata_DGM:Geodata_DGM_quality_license ] ;
+            sh:name "creationDate"@en ;
+            sh:path Geodata_DGM:Geodata_DGM_quality_creationDate ] ;
     sh:targetClass Geodata_DGM:Asset .
 

--- a/Geodata_DGM/Geodata_DGM_shacl.ttl
+++ b/Geodata_DGM/Geodata_DGM_shacl.ttl
@@ -1,0 +1,36 @@
+@prefix Geodata_DGM: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Geodata_DGM_ontology> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+Geodata_DGM:Asset_Shape a sh:NodeShape ;
+    sh:property [ skos:example "XYZ, Shape, ASCII" ;
+            sh:datatype xsd:string ;
+            sh:description "Data format"@en ;
+            sh:message "Validation of format failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "format"@en ;
+            sh:path Geodata_DGM:Geodata_DGM_quality_format ],
+        [ skos:example "2011-11-11 00:00:00" ;
+            sh:datatype xsd:string ;
+            sh:description "Creation Date"@en ;
+            sh:message "Validation of creationDate failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "creationDate"@en ;
+            sh:path Geodata_DGM:Geodata_DGM_quality_creationDate ],
+        [ skos:example "1" ;
+            sh:datatype xsd:int ;
+            sh:description "Resolution of the dataset"@en ;
+            sh:message "Validation of resolution failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "resolution"@en ;
+            sh:path Geodata_DGM:Geodata_DGM_quality_resolution ],
+        [ skos:example "LDBV Commercial" ;
+            sh:datatype xsd:anyURI ;
+            sh:description "License"@en ;
+            sh:message "Validation of license failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "license"@en ;
+            sh:path Geodata_DGM:Geodata_DGM_quality_license ] ;
+    sh:targetClass Geodata_DGM:Asset .
+


### PR DESCRIPTION
The ontology was created on 02/27/2014 with the latest version of the Ontology Creator and uses the current Excel file as input: Metadata, which was created in collaboration with all data providers from the GAIA-X4PLCC-AAD project and can now be merged into the main branch.

Signed-off-by: jtdemer <johannes.demer@asc-s.de>