### PR TITLE
Adding the Geodata_DOP Ontology

### DIFF
--- a/Geodata_DOP/Geodata_DOP_ontology.ttl
+++ b/Geodata_DOP/Geodata_DOP_ontology.ttl
@@ -1,4 +1,4 @@
-@prefix Geodata_DOP: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Geodata_DOP_ontology/> .
+@prefix Geodata_DOP: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/tools/ontologie_creator/ontologies/Geodata_DOP_ontology/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix gax-core: <https://w3id.org/gaia-x/core#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -10,7 +10,7 @@ Geodata_DOP: a owl:Ontology ;
     dcterms:contributor "Maximilian Sindram (VCS)" ;
     owl:versionInfo "0.1"^^xsd:float .
 
-Geodata_DOP:Geodata_DOP a owl:Class ;
+Geodata_DOP:Asset a owl:Class ;
     rdfs:label "Geodata_DOP" ;
     rdfs:comment "attributes for DOP"@en ;
     rdfs:subClassOf gax-core:Resource .

--- a/Geodata_DOP/Geodata_DOP_ontology.ttl
+++ b/Geodata_DOP/Geodata_DOP_ontology.ttl
@@ -1,0 +1,17 @@
+@prefix Geodata_DOP: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Geodata_DOP_ontology/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix gax-core: <https://w3id.org/gaia-x/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+Geodata_DOP: a owl:Ontology ;
+    rdfs:label "ontology definition for Geodata_DOP"@en ;
+    dcterms:contributor "Maximilian Sindram (VCS)" ;
+    owl:versionInfo "0.1"^^xsd:float .
+
+Geodata_DOP:Geodata_DOP a owl:Class ;
+    rdfs:label "Geodata_DOP" ;
+    rdfs:comment "attributes for DOP"@en ;
+    rdfs:subClassOf gax-core:Resource .
+

--- a/Geodata_DOP/Geodata_DOP_shacl.ttl
+++ b/Geodata_DOP/Geodata_DOP_shacl.ttl
@@ -1,36 +1,36 @@
-@prefix Geodata_DOP: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Geodata_DOP_ontology> .
+@prefix Geodata_DOP: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/tools/ontologie_creator/ontologies/Geodata_DOP_ontology/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 Geodata_DOP:Asset_Shape a sh:NodeShape ;
-    sh:property [ skos:example "2011-11-11 00:00:00" ;
-            sh:datatype xsd:string ;
-            sh:description "Creation Date"@en ;
-            sh:message "Validation of creationDate failed!"@en ;
-            sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "creationDate"@en ;
-            sh:path Geodata_DOP:Geodata_DOP_quality_creationDate ],
-        [ skos:example "Jpeg, Tiff" ;
+    sh:property [ skos:example "Jpeg, Tiff" ;
             sh:datatype xsd:string ;
             sh:description "Data format"@en ;
             sh:message "Validation of format failed!"@en ;
             sh:minCount "0"^^xsd:unsignedInt ;
             sh:name "format"@en ;
             sh:path Geodata_DOP:Geodata_DOP_quality_format ],
-        [ skos:example "1" ;
-            sh:datatype xsd:int ;
-            sh:description "Resolution of the dataset"@en ;
-            sh:message "Validation of resolution failed!"@en ;
+        [ skos:example "2011-11-11 00:00:00" ;
+            sh:datatype xsd:string ;
+            sh:description "Creation Date"@en ;
+            sh:message "Validation of creationDate failed!"@en ;
             sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "resolution"@en ;
-            sh:path Geodata_DOP:Geodata_DOP_quality_resolution ],
+            sh:name "creationDate"@en ;
+            sh:path Geodata_DOP:Geodata_DOP_quality_creationDate ],
         [ skos:example "LDBV Commercial" ;
             sh:datatype xsd:anyURI ;
             sh:description "License"@en ;
             sh:message "Validation of license failed!"@en ;
             sh:minCount "0"^^xsd:unsignedInt ;
             sh:name "license"@en ;
-            sh:path Geodata_DOP:Geodata_DOP_quality_license ] ;
+            sh:path Geodata_DOP:Geodata_DOP_quality_license ],
+        [ skos:example "1" ;
+            sh:datatype xsd:int ;
+            sh:description "Resolution of the dataset"@en ;
+            sh:message "Validation of resolution failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "resolution"@en ;
+            sh:path Geodata_DOP:Geodata_DOP_quality_resolution ] ;
     sh:targetClass Geodata_DOP:Asset .
 

--- a/Geodata_DOP/Geodata_DOP_shacl.ttl
+++ b/Geodata_DOP/Geodata_DOP_shacl.ttl
@@ -1,0 +1,36 @@
+@prefix Geodata_DOP: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Geodata_DOP_ontology> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+Geodata_DOP:Asset_Shape a sh:NodeShape ;
+    sh:property [ skos:example "2011-11-11 00:00:00" ;
+            sh:datatype xsd:string ;
+            sh:description "Creation Date"@en ;
+            sh:message "Validation of creationDate failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "creationDate"@en ;
+            sh:path Geodata_DOP:Geodata_DOP_quality_creationDate ],
+        [ skos:example "Jpeg, Tiff" ;
+            sh:datatype xsd:string ;
+            sh:description "Data format"@en ;
+            sh:message "Validation of format failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "format"@en ;
+            sh:path Geodata_DOP:Geodata_DOP_quality_format ],
+        [ skos:example "1" ;
+            sh:datatype xsd:int ;
+            sh:description "Resolution of the dataset"@en ;
+            sh:message "Validation of resolution failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "resolution"@en ;
+            sh:path Geodata_DOP:Geodata_DOP_quality_resolution ],
+        [ skos:example "LDBV Commercial" ;
+            sh:datatype xsd:anyURI ;
+            sh:description "License"@en ;
+            sh:message "Validation of license failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "license"@en ;
+            sh:path Geodata_DOP:Geodata_DOP_quality_license ] ;
+    sh:targetClass Geodata_DOP:Asset .
+


### PR DESCRIPTION
The ontology was created on 02/27/2014 with the latest version of the Ontology Creator and uses the current Excel file as input: Metadata, which was created in collaboration with all data providers from the GAIA-X4PLCC-AAD project and can now be merged into the main branch.

Signed-off-by: jtdemer <johannes.demer@asc-s.de>