### PR TITLE
Adding the Simulation-Configuration Ontology

### DIFF
--- a/Simulation-Configuration/Simulation-Configuration_ontology.ttl
+++ b/Simulation-Configuration/Simulation-Configuration_ontology.ttl
@@ -1,0 +1,17 @@
+@prefix Simulation-Configuration: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Simulation-Configuration_ontology/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix gax-core: <https://w3id.org/gaia-x/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+Simulation-Configuration: a owl:Ontology ;
+    rdfs:label "ontology definition for Simulation-Configuration"@en ;
+    dcterms:contributor "Maurizio Ahmann (SL)" ;
+    owl:versionInfo "0.1"^^xsd:float .
+
+Simulation-Configuration:Simulation-Configuration a owl:Class ;
+    rdfs:label "Simulation-Configuration" ;
+    rdfs:comment "attributes for SSP"@en ;
+    rdfs:subClassOf gax-core:Resource .
+

--- a/Simulation-Configuration/Simulation-Configuration_ontology.ttl
+++ b/Simulation-Configuration/Simulation-Configuration_ontology.ttl
@@ -1,4 +1,4 @@
-@prefix Simulation-Configuration: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Simulation-Configuration_ontology/> .
+@prefix Simulation-Configuration: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/tools/ontologie_creator/ontologies/Simulation-Configuration_ontology/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix gax-core: <https://w3id.org/gaia-x/core#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -10,7 +10,7 @@ Simulation-Configuration: a owl:Ontology ;
     dcterms:contributor "Maurizio Ahmann (SL)" ;
     owl:versionInfo "0.1"^^xsd:float .
 
-Simulation-Configuration:Simulation-Configuration a owl:Class ;
+Simulation-Configuration:Asset a owl:Class ;
     rdfs:label "Simulation-Configuration" ;
     rdfs:comment "attributes for SSP"@en ;
     rdfs:subClassOf gax-core:Resource .

--- a/Simulation-Configuration/Simulation-Configuration_shacl.ttl
+++ b/Simulation-Configuration/Simulation-Configuration_shacl.ttl
@@ -1,82 +1,16 @@
-@prefix Simulation-Configuration: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Simulation-Configuration_ontology> .
+@prefix Simulation-Configuration: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/tools/ontologie_creator/ontologies/Simulation-Configuration_ontology/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 Simulation-Configuration:Asset_Shape a sh:NodeShape ;
-    sh:property [ skos:example "OS: Windows x64, Tools: MatlabRuntime R2015a, Libraries: e.g." ;
-            sh:datatype xsd:string ;
-            sh:description "required OS, Tools, Libraries"@en ;
-            sh:message "Validation of SystemRequirements failed!"@en ;
-            sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "SystemRequirements"@en ;
-            sh:path Simulation-Configuration:Simulation-Configuration_quality_SystemRequirements ],
-        [ skos:example "true" ;
+    sh:property [ skos:example "true" ;
             sh:datatype xsd:boolean ;
             sh:description "indicates if a default experiment is defined"@en ;
             sh:message "Validation of hasDefaultExperiment failed!"@en ;
             sh:minCount "0"^^xsd:unsignedInt ;
             sh:name "hasDefaultExperiment"@en ;
             sh:path Simulation-Configuration:Simulation-Configuration_quality_hasDefaultExperiment ],
-        [ skos:example "true" ;
-            sh:datatype xsd:boolean ;
-            sh:description "indicated if a SSP Traceability information is appended (Simulation Task Meta Data)"@en ;
-            sh:message "Validation of hasSTMD failed!"@en ;
-            sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "hasSTMD"@en ;
-            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSTMD ],
-        [ skos:example "copyright 2023 Awesome Sim Ltd. All rights reserved" ;
-            sh:datatype xsd:string ;
-            sh:description """Optional attribute giving information about copyrights of the contents of
-this file"""@en ;
-            sh:message "Validation of copyright failed!"@en ;
-            sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "copyright"@en ;
-            sh:path Simulation-Configuration:Simulation-Configuration_quality_copyright ],
-        [ skos:example "true" ;
-            sh:datatype xsd:boolean ;
-            sh:description "indicates if an SSM (System Structure Parameter Mapping) is contained in the package"@en ;
-            sh:message "Validation of hasSSM failed!"@en ;
-            sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "hasSSM"@en ;
-            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSSM ],
-        [ skos:example "true" ;
-            sh:datatype xsd:boolean ;
-            sh:description "indicates if an SSV (System Structure Parameter Values) is contained in the package"@en ;
-            sh:message "Validation of hasSSV failed!"@en ;
-            sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "hasSSV"@en ;
-            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSSV ],
-        [ skos:example "1.0" ;
-            sh:datatype xsd:string ;
-            sh:description "SSP version"@en ;
-            sh:message "Validation of Version failed!"@en ;
-            sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "Version"@en ;
-            sh:path Simulation-Configuration:Simulation-Configuration_quality_Version ],
-        [ skos:example "John Doe, Awesome Sim Ltd." ;
-            sh:datatype xsd:string ;
-            sh:description """Optional attribute giving the name and/or organization of the author of
-the contents of this file."""@en ;
-            sh:message "Validation of author failed!"@en ;
-            sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "author"@en ;
-            sh:path Simulation-Configuration:Simulation-Configuration_quality_author ],
-        [ skos:example "5" ;
-            sh:datatype xsd:int ;
-            sh:description "Configured Models for the Simulation / Proposal: Number of elements (on the first layer) of the system"@en ;
-            sh:message "Validation of NumberOfModels_[NumberOfElements] failed!"@en ;
-            sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "NumberOfModels_[NumberOfElements]"@en ;
-            sh:path <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Simulation-Configuration_ontologySimulation-Configuration_quality_NumberOfModels_[NumberOfElements]> ],
-        [ skos:example "AVL Model.CONNECT R2021.1" ;
-            sh:datatype xsd:boolean ;
-            sh:description """Optional attribute giving information about the tool used to generate this
-file."""@en ;
-            sh:message "Validation of generationTool failed!"@en ;
-            sh:minCount "0"^^xsd:unsignedInt ;
-            sh:name "generationTool"@en ;
-            sh:path Simulation-Configuration:Simulation-Configuration_quality_generationTool ],
         [ skos:example "LDBV Commercial" ;
             sh:datatype xsd:string ;
             sh:description """Optional attribute giving information about licensing of the contents of
@@ -85,12 +19,78 @@ this file. """@en ;
             sh:minCount "0"^^xsd:unsignedInt ;
             sh:name "license"@en ;
             sh:path Simulation-Configuration:Simulation-Configuration_quality_license ],
+        [ skos:example "OS: Windows x64, Tools: MatlabRuntime R2015a, Libraries: e.g." ;
+            sh:datatype xsd:string ;
+            sh:description "required OS, Tools, Libraries"@en ;
+            sh:message "Validation of SystemRequirements failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "SystemRequirements"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_SystemRequirements ],
+        [ skos:example "5" ;
+            sh:datatype xsd:int ;
+            sh:description "Configured Models for the Simulation / Proposal: Number of elements (on the first layer) of the system"@en ;
+            sh:message "Validation of NumberOfModels_[NumberOfElements] failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "NumberOfModels_[NumberOfElements]"@en ;
+            sh:path <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/tools/ontologie_creator/ontologies/Simulation-Configuration_ontology/Simulation-Configuration_quality_NumberOfModels_[NumberOfElements]> ],
+        [ skos:example "John Doe, Awesome Sim Ltd." ;
+            sh:datatype xsd:string ;
+            sh:description """Optional attribute giving the name and/or organization of the author of
+the contents of this file."""@en ;
+            sh:message "Validation of author failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "author"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_author ],
+        [ skos:example "true" ;
+            sh:datatype xsd:boolean ;
+            sh:description "indicates if an SSM (System Structure Parameter Mapping) is contained in the package"@en ;
+            sh:message "Validation of hasSSM failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "hasSSM"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSSM ],
+        [ skos:example "copyright 2023 Awesome Sim Ltd. All rights reserved" ;
+            sh:datatype xsd:string ;
+            sh:description """Optional attribute giving information about copyrights of the contents of
+this file"""@en ;
+            sh:message "Validation of copyright failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "copyright"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_copyright ],
+        [ skos:example "1.0" ;
+            sh:datatype xsd:string ;
+            sh:description "SSP version"@en ;
+            sh:message "Validation of Version failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "Version"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_Version ],
+        [ skos:example "true" ;
+            sh:datatype xsd:boolean ;
+            sh:description "indicated if a SSP Traceability information is appended (Simulation Task Meta Data)"@en ;
+            sh:message "Validation of hasSTMD failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "hasSTMD"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSTMD ],
+        [ skos:example "AVL Model.CONNECT R2021.1" ;
+            sh:datatype xsd:boolean ;
+            sh:description """Optional attribute giving information about the tool used to generate this
+file."""@en ;
+            sh:message "Validation of generationTool failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "generationTool"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_generationTool ],
         [ skos:example "false" ;
             sh:datatype xsd:boolean ;
             sh:description "indicates if an SSB (System Structure Signal Dictionary) is contained in the package"@en ;
             sh:message "Validation of hasSSB failed!"@en ;
             sh:minCount "0"^^xsd:unsignedInt ;
             sh:name "hasSSB"@en ;
-            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSSB ] ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSSB ],
+        [ skos:example "true" ;
+            sh:datatype xsd:boolean ;
+            sh:description "indicates if an SSV (System Structure Parameter Values) is contained in the package"@en ;
+            sh:message "Validation of hasSSV failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "hasSSV"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSSV ] ;
     sh:targetClass Simulation-Configuration:Asset .
 

--- a/Simulation-Configuration/Simulation-Configuration_shacl.ttl
+++ b/Simulation-Configuration/Simulation-Configuration_shacl.ttl
@@ -1,0 +1,96 @@
+@prefix Simulation-Configuration: <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Simulation-Configuration_ontology> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+Simulation-Configuration:Asset_Shape a sh:NodeShape ;
+    sh:property [ skos:example "OS: Windows x64, Tools: MatlabRuntime R2015a, Libraries: e.g." ;
+            sh:datatype xsd:string ;
+            sh:description "required OS, Tools, Libraries"@en ;
+            sh:message "Validation of SystemRequirements failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "SystemRequirements"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_SystemRequirements ],
+        [ skos:example "true" ;
+            sh:datatype xsd:boolean ;
+            sh:description "indicates if a default experiment is defined"@en ;
+            sh:message "Validation of hasDefaultExperiment failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "hasDefaultExperiment"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasDefaultExperiment ],
+        [ skos:example "true" ;
+            sh:datatype xsd:boolean ;
+            sh:description "indicated if a SSP Traceability information is appended (Simulation Task Meta Data)"@en ;
+            sh:message "Validation of hasSTMD failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "hasSTMD"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSTMD ],
+        [ skos:example "copyright 2023 Awesome Sim Ltd. All rights reserved" ;
+            sh:datatype xsd:string ;
+            sh:description """Optional attribute giving information about copyrights of the contents of
+this file"""@en ;
+            sh:message "Validation of copyright failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "copyright"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_copyright ],
+        [ skos:example "true" ;
+            sh:datatype xsd:boolean ;
+            sh:description "indicates if an SSM (System Structure Parameter Mapping) is contained in the package"@en ;
+            sh:message "Validation of hasSSM failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "hasSSM"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSSM ],
+        [ skos:example "true" ;
+            sh:datatype xsd:boolean ;
+            sh:description "indicates if an SSV (System Structure Parameter Values) is contained in the package"@en ;
+            sh:message "Validation of hasSSV failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "hasSSV"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSSV ],
+        [ skos:example "1.0" ;
+            sh:datatype xsd:string ;
+            sh:description "SSP version"@en ;
+            sh:message "Validation of Version failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "Version"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_Version ],
+        [ skos:example "John Doe, Awesome Sim Ltd." ;
+            sh:datatype xsd:string ;
+            sh:description """Optional attribute giving the name and/or organization of the author of
+the contents of this file."""@en ;
+            sh:message "Validation of author failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "author"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_author ],
+        [ skos:example "5" ;
+            sh:datatype xsd:int ;
+            sh:description "Configured Models for the Simulation / Proposal: Number of elements (on the first layer) of the system"@en ;
+            sh:message "Validation of NumberOfModels_[NumberOfElements] failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "NumberOfModels_[NumberOfElements]"@en ;
+            sh:path <https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/Simulation-Configuration_ontologySimulation-Configuration_quality_NumberOfModels_[NumberOfElements]> ],
+        [ skos:example "AVL Model.CONNECT R2021.1" ;
+            sh:datatype xsd:boolean ;
+            sh:description """Optional attribute giving information about the tool used to generate this
+file."""@en ;
+            sh:message "Validation of generationTool failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "generationTool"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_generationTool ],
+        [ skos:example "LDBV Commercial" ;
+            sh:datatype xsd:string ;
+            sh:description """Optional attribute giving information about licensing of the contents of
+this file. """@en ;
+            sh:message "Validation of license failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "license"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_license ],
+        [ skos:example "false" ;
+            sh:datatype xsd:boolean ;
+            sh:description "indicates if an SSB (System Structure Signal Dictionary) is contained in the package"@en ;
+            sh:message "Validation of hasSSB failed!"@en ;
+            sh:minCount "0"^^xsd:unsignedInt ;
+            sh:name "hasSSB"@en ;
+            sh:path Simulation-Configuration:Simulation-Configuration_quality_hasSSB ] ;
+    sh:targetClass Simulation-Configuration:Asset .
+


### PR DESCRIPTION
The ontology was created on 02/27/2014 with the latest version of the Ontology Creator and uses the current Excel file as input: Metadata, which was created in collaboration with all data providers from the GAIA-X4PLCC-AAD project and can now be merged into the main branch.

Signed-off-by: jtdemer <johannes.demer@asc-s.de>