### PR TITLE
adapted naming convention in example folder. belongs_to -> belongsTo

### DIFF
--- a/example/VARIABLES.md
+++ b/example/VARIABLES.md
@@ -11,9 +11,9 @@
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | ExampleServiceOfferingShape | description_ontology | property1 | 1 |  | A description that describes property 1. | <http://www.w3.org/2001/XMLSchema#string> | description_shacl.ttl |
 | ExampleServiceOfferingShape | description_ontology | property2 | 1 |  | A description that describes property 2. | <http://www.w3.org/2001/XMLSchema#string> | description_shacl.ttl |
-| ExampleServiceOfferingShape | description_ontology | belongs_to | 1 |  | Identifier of related Self Description. | <http://www.w3.org/ns/shacl#IRI> | description_shacl.ttl |
+| ExampleServiceOfferingShape | description_ontology | belongsTo | 1 |  | Identifier of related Self Description. | <http://www.w3.org/ns/shacl#IRI> | description_shacl.ttl |
 | ExampleServiceOfferingShape | description_ontology | hasJunctionIntersection | 1 | 1 | Further description of the content of the scenario | <http://www.w3.org/ns/shacl#IRI> | description_shacl.ttl |
 | ExampleServiceOfferingShape | example_ontology | property1 | 1 |  | A description that describes property 1. | <http://www.w3.org/2001/XMLSchema#string> | example_shacl.ttl |
 | ExampleServiceOfferingShape | example_ontology | property2 | 1 |  | A description that describes property 2. | <http://www.w3.org/2001/XMLSchema#string> | example_shacl.ttl |
-| ExampleServiceOfferingShape | example_ontology | belongs_to | 1 |  | Identifier of related Self Description. | <http://www.w3.org/ns/shacl#IRI> | example_shacl.ttl |
+| ExampleServiceOfferingShape | example_ontology | belongsTo | 1 |  | Identifier of related Self Description. | <http://www.w3.org/ns/shacl#IRI> | example_shacl.ttl |
 | ExampleServiceOfferingShape | example_ontology | hasJunctionIntersection | 1 | 1 | Further description of the content of the scenario | <http://www.w3.org/ns/shacl#IRI> | example_shacl.ttl |

--- a/example/description_instance.json
+++ b/example/description_instance.json
@@ -22,7 +22,7 @@
     "@value": "value of property 2",
     "@type": "xsd:string"
   },
-  "description_ontology:belongs_to": {
+  "description_ontology:belongsTo": {
     "@id": "https://www.example.org/id"
   },
   "description_ontology:hasJunctionIntersection": {

--- a/example/description_ontology.ttl
+++ b/example/description_ontology.ttl
@@ -67,8 +67,8 @@
     rdfs:comment "Describes an example Service Offering."@en .
 
 # Whenever we use a property which is referencing another node, we need to specify its domain and range within the ontology
-<belongs_to> rdf:type owl:ObjectProperty ;
-    # In general terms, we use domain and range as follows: Domain Property Range. In our case: Domain belongs_to Range.
+<belongsTo> rdf:type owl:ObjectProperty ;
+    # In general terms, we use domain and range as follows: Domain Property Range. In our case: Domain belongsTo Range.
     # In our example we relate to another instance of the same class. The relation could also be made between different classes.
     # In this case we use the domain "ExampleServiceOffering", which means that this property is used to describe an ExampleServiceOffering
     rdfs:domain <ExampleServiceOffering> ;

--- a/example/description_shacl.ttl
+++ b/example/description_shacl.ttl
@@ -37,7 +37,7 @@ description_ontology:ExampleServiceOfferingShape # This is the subject our predi
 	] ;
 	sh:property # This property is special in a way that it provides the possibility to link to another class. Whenever you use a property linking between classes, you need to specify the domain & range of the regarding property in an ontology (have a look into the description_ontology-file for more information).
 	[
-	  sh:path description_ontology:belongs_to ;
+	  sh:path description_ontology:belongsTo ;
 	  sh:nodeKind sh:IRI ; # This attribute is set instead of "sh:datatype". It denotes that this property needs to have a node, which is expressed in form of an IRI. This enables linkage between different classes.
 	  sh:minCount 1 ;
 	  sh:message "Validation of Identifier of related Self Description failed" ;

--- a/example/example_instance.json
+++ b/example/example_instance.json
@@ -22,7 +22,7 @@
       "@type": "xsd:string"
     }
   ],
-  "description_ontology:belongs_to": {
+  "description_ontology:belongsTo": {
     "@id": "https://www.example.org/id"
   },
   "description_ontology:hasJunctionIntersection": {

--- a/example/example_ontology.ttl
+++ b/example/example_ontology.ttl
@@ -16,6 +16,6 @@
     rdfs:label "Example Service Offering"@en ;
     rdfs:comment "Describes an example Service Offering."@en .
 
-<belongs_to> rdf:type owl:ObjectProperty ;
+<belongsTo> rdf:type owl:ObjectProperty ;
     rdfs:domain <ExampleServiceOffering> ;
     rdfs:range <ExampleServiceOffering> .

--- a/example/example_shacl.ttl
+++ b/example/example_shacl.ttl
@@ -31,7 +31,7 @@ example_ontology:ExampleServiceOfferingShape
 	] ;
 	sh:property
 	[
-		  sh:path example_ontology:belongs_to ;
+		  sh:path example_ontology:belongsTo ;
 		  sh:nodeKind sh:IRI ;
 		  sh:minCount 1 ;
 		  sh:message "Validation of Identifier of related Self Description failed" ;


### PR DESCRIPTION
# Description

changed belongs_to to belongsTo in example folder

## Type of change

Please delete options that are not relevant.

- [ ] New type (non-breaking change which adds a type)
- [x] Change (non-breaking change or fix on an existing type)
- [ ] Breaking change (Change that would cause existing Self Descriptions not to be accepted anymore by a Federated Catalogue)

