### PR TITLE
OSI Trace File Ontology

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,3 +47,6 @@
 /surface-model @robertschubert
 /surface-model @3Dbastian
 
+# ositrace directory (Pierre AND Robert)
+/ositrace @robertschubert
+/ositrace @pmai

--- a/ositrace/VARIABLES.md
+++ b/ositrace/VARIABLES.md
@@ -1,0 +1,44 @@
+# Variables of SHACL Files in this folder
+
+## Prefixes
+
+- ositrace: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/ositrace/>
+
+## List of SHACL Properties
+
+| Shape | Property prefix | Property | MinCount | MaxCount | Description | Datatype/NodeKind | Filename |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| OSITraceShape | ositrace | general | 1 | 1 |  |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | format | 1 | 1 |  |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | content | 1 | 1 |  |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | quality | 1 | 1 |  |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | quantity | 1 | 1 |  |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | dataSource | 1 | 1 |  |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | georeference | 1 | 1 |  |  | ositrace_shacl.ttl |
+| ContentShape | ositrace | roadTypes |  |  | Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3 | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| ContentShape | ositrace | laneTypes |  |  | Covered lane types, see ODR spec section 9.5.3. | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| ContentShape | ositrace | levelOfDetail |  |  | Covered object classes, see ODR spec section 11 | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| ContentShape | ositrace | trafficDirection |  | 1 | Traffic direction, i.e. right-hand or left-hand traffic | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| ContentShape | ositrace | granularity | 1 |  | Level of granularity of sensor data | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| ContentShape | ositrace | scenarioIdentifier |  |  | Identifier of scenario performed in the trace file | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| ContentShape | ositrace | startTime | 1 | 1 | Exact start timestamp of the recorded trace | <http://www.w3.org/2001/XMLSchema#dateTimeStamp> | ositrace_shacl.ttl |
+| ContentShape | ositrace | stopTime | 1 | 1 | Exact stop timestamp of the recorded trace | <http://www.w3.org/2001/XMLSchema#dateTimeStamp> | ositrace_shacl.ttl |
+| ContentShape | ositrace | hostMovingObject |  | 1 | Host moving object in trace file |  | ositrace_shacl.ttl |
+| ContentShape | ositrace | targetMovingObject |  |  | Target moving object in trace file |  | ositrace_shacl.ttl |
+| ContentShape | ositrace | event |  |  | Description of event of interest in trace file |  | ositrace_shacl.ttl |
+| DataSourceShape | ositrace | measurementSystem |  | 1 | Main acquisition device | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| DataSourceShape | ositrace | usedDataSources |  |  | Basic data for the creation of the trace  | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| FormatShape | ositrace | version |  | 1 | Version of data format | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| FormatShape | ositrace | type |  | 1 | Format type definition | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| QualityShape | ositrace | accuracySignals | 0 | 1 | Accuracy of traffic relevant objects, signs and signals | <http://www.w3.org/2001/XMLSchema#float> | ositrace_shacl.ttl |
+| QualityShape | ositrace | accuracyObjects | 0 | 1 | Accuracy of objects in the traffic space, which do not directly affect the traffic | <http://www.w3.org/2001/XMLSchema#float> | ositrace_shacl.ttl |
+| QualityShape | ositrace | accuracyLaneModelHeight | 0 | 1 | Accuracy lane modell height | <http://www.w3.org/2001/XMLSchema#float> | ositrace_shacl.ttl |
+| QualityShape | ositrace | precision | 0 | 1 | Precision of measured road network (relative accuracy) | <http://www.w3.org/2001/XMLSchema#float> | ositrace_shacl.ttl |
+| QualityShape | ositrace | accuracyLaneModel2d | 0 | 1 | Accuracy of lane modell 2d | <http://www.w3.org/2001/XMLSchema#float> | ositrace_shacl.ttl |
+| QualityShape | ositrace | calibration | 0 | 1 | Description of any calibration steps performed prior to measurement | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| QuantityShape | ositrace | numberFrames |  | 1 | Number of frames/messages in the trace file | <http://www.w3.org/2001/XMLSchema#unsignedInt> | ositrace_shacl.ttl |
+| MovingObjectShape | ositrace | identifier |  |  | Moving object identifier in trace file | <http://www.w3.org/2001/XMLSchema#unsignedLong> | ositrace_shacl.ttl |
+| MovingObjectShape | ositrace | description |  | 1 | Description of moving object in the trace file | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| EventShape | ositrace | time | 1 | 1 | Exact timestamp of the event in the recorded trace | <http://www.w3.org/2001/XMLSchema#dateTimeStamp> | ositrace_shacl.ttl |
+| EventShape | ositrace | tag |  |  | Unique tag of the event in trace file | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| EventShape | ositrace | description |  | 1 | Description of event in the trace file | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |

--- a/ositrace/ositrace_instance.json
+++ b/ositrace/ositrace_instance.json
@@ -1,0 +1,204 @@
+{
+  "@context": {
+    "general": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/general/",
+    "gx": "https://registry.lab.gaia-x.eu/development/api/trusted-shape-registry/v1/shapes/jsonld/trustframework#",
+    "ositrace": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/ositrace/",
+    "sh": "http://www.w3.org/ns/shacl#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
+  },
+  "@id": "did:web:registry.gaia-x.eu:OSITrace:T9rkdS19poUrbbAEk3rXMqZ3hzVezwDrrxaf",
+  "@type": "ositrace:OSITrace",
+  "ositrace:general": {
+    "@type": "general:General",
+    "general:description": {
+      "@type": "general:Description",
+      "gx:name": {
+        "@value": "Cut-out scenario on testing ground",
+        "@type": "xsd:string"
+      },
+      "gx:description": {
+        "@value": "OSI SensorData trace of cut-out scenario on testing ground",
+        "@type": "xsd:string"
+      }
+    },
+    "general:data": {
+      "@type": "general:Data",
+      "general:size": {
+        "@value": "126",
+        "@type": "xsd:float"
+      },
+      "general:contractId": {
+        "@value": "123456789",
+        "@type": "xsd:string"
+      },
+      "general:recordingTime": {
+        "@value": "2024-06-03T16:37:10",
+        "@type": "xsd:dateTime"
+      }
+    },
+    "general:links": {
+      "@type": "general:Links",
+      "general:data": {
+        "@type": "general:Link",
+        "general:url": {
+          "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/20240603T143710.835792Z_sd_360_3200_1448_pmsf_ars548_054814_119_cutout.osi",
+          "@type": "xsd:anyURI"
+        },
+        "general:type": "Asset"
+      },
+      "general:media": {
+        "@type": "general:Link",
+        "general:url": {
+          "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/20240603T143715.300000Z_position_pmsf_zedf9p_119_cutout.gpx",
+          "@type": "xsd:anyURI"
+        },
+        "general:type": "Routing"
+      }
+    },
+    "general:bundleData": {
+      "@type": "general:BundleData",
+      "general:requiredData": {
+        "@type": "general:Link"
+      },
+      "general:relatedData": {
+        "@type": "general:Link"
+      }
+    }
+  },
+  "ositrace:format": {
+    "@type": "ositrace:Format",
+    "ositrace:type": "ASAM OSI SensorData",
+    "ositrace:version": {
+      "@value": "3.6.0/3.20.0",
+      "@type": "xsd:string"
+    }
+  },
+  "ositrace:content": {
+    "@type": "ositrace:Content",
+    "ositrace:roadTypes": "Rural",
+    "ositrace:laneTypes": "driving",
+    "ositrace:levelOfDetail": "car",
+    "ositrace:trafficDirection": "right-hand",
+    "ositrace:granularity": [
+      "object list",
+      "detection list"
+    ],
+    "ositrace:startTime": {
+      "@value": "2024-06-03 16:37:10.835792+02:00",
+      "@type": "xsd:dateTimeStamp"
+    },
+    "ositrace:stopTime": {
+      "@value": "2024-06-03T16:38:28.636671+02:00",
+      "@type": "xsd:dateTimeStamp"
+    },
+    "ositrace:hostMovingObject": {
+      "@type": "ositrace:MovingObject",
+      "ositrace:identifier": {
+        "@value": "1",
+        "@type": "xsd:unsignedLong"
+      },
+      "ositrace:description": {
+        "@value": "PMSF MB CLS 500 Host Vehicle",
+        "@type": "xsd:string"
+      }
+    },
+    "ositrace:targetMovingObject": {
+      "@type": "ositrace:MovingObject",
+      "ositrace:identifier": {
+        "@value": "2",
+        "@type": "xsd:unsignedLong"
+      },
+      "ositrace:description": {
+        "@value": "ADC Target Vehicle",
+        "@type": "xsd:string"
+      }
+    }  
+  },
+  "ositrace:quality": {
+    "@type": "ositrace:Quality"
+  },
+  "ositrace:quantity": {
+    "@type": "ositrace:Quantity",
+    "ositrace:numberFrames": {
+      "@value": "1448",
+      "@type": "xsd:unsignedInt"
+    }
+  },
+  "ositrace:dataSource": {
+    "@type": "ositrace:DataSource",
+    "ositrace:usedDataSources": {
+      "@value": "Direct Sensor Capture ARS 548 FW05.38.14 on PMSF MB CLS 500",
+      "@type": "xsd:string"
+    },
+    "ositrace:measurementSystem": {
+      "@value": "pcapng2osi converter v1.1",
+      "@type": "xsd:string"
+    }
+  },
+  "ositrace:georeference": {
+    "@type": "georeference:GeoreferenceShape",
+    "georeference:projectLocation": {
+      "@type": "georeference:ProjectLocation",
+      "georeference:country": {
+        "@value": "DE-NI",
+        "@type": "xsd:string"
+      },
+      "georeference:state": {
+        "@value": "Lower Saxony",
+        "@type": "xsd:string"
+      },
+      "georeference:region": {
+        "@value": "Brunswick",
+        "@type": "xsd:string"
+      },
+      "georeference:city": {
+        "@value": "Edemissen",
+        "@type": "xsd:string"
+      },
+      "georeference:relationOrArea": {
+        "@value": "Airport Peine-Eddesse",
+        "@type": "xsd:string"
+      },
+      "georeference:boundingBox": {
+        "@type": "georeference:BoundingBox",
+        "georeference:xMin": {
+          "@value": "52.40177964666667",
+          "@type": "xsd:float"
+        },
+        "georeference:yMin": {
+          "@value": "10.22518251",
+          "@type": "xsd:float"
+        },
+        "georeference:xMax": {
+          "@value": "52.403132605",
+          "@type": "xsd:float"
+        },
+        "georeference:yMax": {
+          "@value": "10.23265636",
+          "@type": "xsd:float"
+        }
+      }
+    },
+    "georeference:geodeticReferenceSystem": {
+      "@type": "georeference:GeodeticReferenceSystem",
+      "georeference:coordinateSystem": {
+        "@value": "EPSG::4326",
+        "@type": "xsd:string"
+      },
+      "georeference:origin": {
+        "@type": "georeference:Coordinate2D",
+        "georeference:x": {
+          "@value": "52.40177964666667",
+          "@type": "xsd:float"
+        },
+        "georeference:y": {
+          "@value": "10.22518251",
+          "@type": "xsd:float"
+        }
+      },
+      "georeference:heightSystem": "Ellipsodial height"
+    }
+  }
+}

--- a/ositrace/ositrace_instance.json
+++ b/ositrace/ositrace_instance.json
@@ -26,7 +26,7 @@
     "general:data": {
       "@type": "general:Data",
       "general:size": {
-        "@value": "126",
+        "@value": "126.6",
         "@type": "xsd:float"
       },
       "general:contractId": {
@@ -60,10 +60,12 @@
     "general:bundleData": {
       "@type": "general:BundleData",
       "general:requiredData": {
-        "@type": "general:Link"
-      },
-      "general:relatedData": {
-        "@type": "general:Link"
+        "@type": "general:Link",
+        "general:url": {
+          "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/LICENSE.md",
+          "@type": "xsd:anyURI"
+        },
+        "general:type": "Document"
       }
     }
   },
@@ -142,11 +144,11 @@
     "georeference:projectLocation": {
       "@type": "georeference:ProjectLocation",
       "georeference:country": {
-        "@value": "DE-NI",
+        "@value": "DE",
         "@type": "xsd:string"
       },
       "georeference:state": {
-        "@value": "Lower Saxony",
+        "@value": "DE-NI",
         "@type": "xsd:string"
       },
       "georeference:region": {

--- a/ositrace/ositrace_ontology.ttl
+++ b/ositrace/ositrace_ontology.ttl
@@ -11,6 +11,34 @@ ositrace: a owl:Ontology ;
     owl:versionInfo "0.1" .
 
 ositrace:OSITrace a owl:Class ;
-    rdfs:label "class definition for OSI Trace Files" ;
+    rdfs:label "Class definition for OSI Trace Files" ;
     rdfs:comment "Attributes for OSI Trace Files"@en ;
     rdfs:subClassOf gx:DataResource .
+
+ositrace:Content a owl:Class ;
+    rdfs:label "Class definition for Content" ;
+    rdfs:comment "Attributes for Content"@en .
+
+ositrace:DataSource a owl:Class ;
+    rdfs:label "Class definition for DataSource" ;
+    rdfs:comment "Attributes for DataSource"@en .
+
+ositrace:Format a owl:Class ;
+    rdfs:label "Class definition for Format" ;
+    rdfs:comment "Attributes for Format"@en .
+
+ositrace:Quality a owl:Class ;
+    rdfs:label "Class definition for Quality" ;
+    rdfs:comment "Attributes for Quality"@en .
+
+ositrace:Quantity a owl:Class ;
+    rdfs:label "Class definition for Quantity" ;
+    rdfs:comment "Attributes for Quantity"@en .
+
+ositrace:MovingObject a owl:Class ;
+    rdfs:label "Class definition for MovingObject" ;
+    rdfs:comment "Attributes for MovingObject"@en .
+
+ositrace:Event a owl:Class ;
+    rdfs:label "Class definition for Event" ;
+    rdfs:comment "Attributes for Event"@en .

--- a/ositrace/ositrace_ontology.ttl
+++ b/ositrace/ositrace_ontology.ttl
@@ -1,0 +1,16 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ositrace: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/ositrace/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix gx: <https://registry.lab.gaia-x.eu/development/api/trusted-shape-registry/v1/shapes/jsonld/trustframework#> .
+
+ositrace: a owl:Ontology ;
+    rdfs:label "ontology definition for OSI Trace Files"@en ;
+    dcterms:contributor "Pierre R. Mai (PMSF)" ;
+    owl:versionInfo "0.1" .
+
+ositrace:OSITrace a owl:Class ;
+    rdfs:label "class definition for OSI Trace Files" ;
+    rdfs:comment "Attributes for OSI Trace Files"@en ;
+    rdfs:subClassOf gx:DataResource .

--- a/ositrace/ositrace_shacl.ttl
+++ b/ositrace/ositrace_shacl.ttl
@@ -1,0 +1,286 @@
+@prefix ositrace: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/ositrace/> .
+@prefix general: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/general/> .
+@prefix georeference: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ositrace:OSITraceShape a sh:NodeShape ;
+    sh:property 
+        [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:node general:GeneralShape ;
+            sh:order 1 ;
+            sh:path ositrace:general ],
+        [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:node ositrace:FormatShape ;
+            sh:order 2 ;
+            sh:path ositrace:format ],
+        [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:node ositrace:ContentShape ;
+            sh:order 3 ;
+            sh:path ositrace:content ],
+        [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:node ositrace:QualityShape ;
+            sh:order 4 ;
+            sh:path ositrace:quality ],
+        [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:node ositrace:QuantityShape ;
+            sh:order 5 ;
+            sh:path ositrace:quantity ],
+        [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:node ositrace:DataSourceShape ;
+            sh:order 6 ;
+            sh:path ositrace:dataSource ],
+        [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:node georeference:GeoreferenceShape ;
+            sh:order 7 ;
+            sh:path ositrace:georeference ] ;
+    sh:targetClass ositrace:OSITrace .
+
+ositrace:ContentShape a sh:NodeShape ;
+    sh:property [ skos:example "[motorway, residential]" ;
+            sh:datatype xsd:string ;
+            sh:description "Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3"@en ;
+            sh:in ("Bicycle" "LowSpeed" "Motorway" "Pedestrian" "Rural" "Town" "TownArterial" "TownCollector" "TownExpressway" "TownLocal" "TownPlayStreet" "TownPrivate" "Unknown") ;
+            sh:message "Validation of roadTypes failed!"@en ;
+            sh:name "roadTypes"@en ;
+            sh:order 0 ;
+            sh:path ositrace:roadTypes ],
+        [ skos:example "shoulder, curb, ..." ;
+            sh:datatype xsd:string ;
+            sh:description "Covered lane types, see ODR spec section 9.5.3."@en ;
+            sh:in ("biking" "border" "connectingRamp" "curb" "driving" "entry" "exit" "median" "none" "offRamp" "onRamp" "parking" "restricted" "shoulder" "slipLane" "stop" "walking") ;
+            sh:message "Validation of laneTypes failed!"@en ;
+            sh:name "laneTypes"@en ;
+            sh:order 1 ;
+            sh:path ositrace:laneTypes ],
+        [ skos:example "trees, street lamps, road patches..." ;
+            sh:datatype xsd:string ;
+            sh:description "Covered object classes, see ODR spec section 11"@en ;
+            sh:in ("barrier" "bike" "building" "bus" "car" "crosswalk" "gantry" "motorbike") ;
+            sh:message "Validation of levelOfDetail failed!"@en ;
+            sh:name "levelOfDetail"@en ;
+            sh:order 2 ;
+            sh:path ositrace:levelOfDetail ], 
+        [ skos:example "right-hand traffic" ;
+            sh:datatype xsd:string ;
+            sh:description "Traffic direction, i.e. right-hand or left-hand traffic"@en ;
+            sh:in ("left-hand" "right-hand") ;
+            sh:maxCount 1 ;
+            sh:message "Validation of trafficDirection failed!"@en ;
+            sh:name "trafficDirection"@en ;
+            sh:order 3 ;
+            sh:path ositrace:trafficDirection ],
+        [ skos:example "object list, detection list" ;
+            sh:datatype xsd:string ;
+            sh:description "Level of granularity of sensor data"@en ;
+            sh:in ("object list" "detection list") ;
+            sh:message "Validation of granularity failed!"@en ;
+            sh:minCount 1 ;
+            sh:name "granularity"@en ;
+            sh:order 4 ;
+            sh:path ositrace:granularity ],
+        [ skos:example "119" ;
+            sh:datatype xsd:string ;
+            sh:description "Identifier of scenario performed in the trace file"@en ;
+            sh:message "Validation of scenarioIdentifier failed!"@en ;
+            sh:name "scenarioIdentifier"@en ;
+            sh:order 5 ;
+            sh:path ositrace:scenarioIdentifier ],
+        [ skos:example "2024-05-11T13:20:03.250320Z" ;
+            sh:datatype xsd:dateTimeStamp ;
+            sh:description "Exact start timestamp of the recorded trace"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of startTime failed!"@en ;
+            sh:minCount 1 ;
+            sh:name "startTime"@en ;
+            sh:order 6 ;
+            sh:path ositrace:startTime ],
+        [ skos:example "2024-05-11T13:20:05.250120Z" ;
+            sh:datatype xsd:dateTimeStamp ;
+            sh:description "Exact stop timestamp of the recorded trace"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of stopTime failed!"@en ;
+            sh:minCount 1 ;
+            sh:name "stopTime"@en ;
+            sh:order 7 ;
+            sh:path ositrace:stopTime ],
+        [ sh:description "Host moving object in trace file"@en ;
+            sh:maxCount 1 ;
+            sh:name "hostMovingObject"@en ;
+            sh:node ositrace:MovingObjectShape ;
+            sh:order 8 ;
+            sh:path ositrace:hostMovingObject ],
+        [ sh:description "Target moving object in trace file"@en ;
+            sh:name "targetMovingObject"@en ;
+            sh:node ositrace:MovingObjectShape ;
+            sh:order 9 ;
+            sh:path ositrace:targetMovingObject ],
+        [ sh:description "Description of event of interest in trace file"@en ;
+            sh:name "event"@en ;
+            sh:node ositrace:EventShape ;
+            sh:order 10 ;
+            sh:path ositrace:event ] ;
+    sh:targetClass ositrace:Content .
+
+ositrace:DataSourceShape a sh:NodeShape ;
+    sh:property [ skos:example "PMSF DroneTracker; ARS 548 Sensor Output" ;
+            sh:datatype xsd:string ;
+            sh:description "Main acquisition device"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of measurementSystem failed!"@en ;
+            sh:name "measurementSystem"@en ;
+            sh:order 1 ;
+            sh:path ositrace:measurementSystem ],
+        [ skos:example "scanner, camera, osm network, aerial images, ..." ;
+            sh:datatype xsd:string ;
+            sh:description "Basic data for the creation of the trace "@en ;
+            sh:message "Validation of usedDataSources failed!"@en ;
+            sh:name "usedDataSources"@en ;
+            sh:order 0 ;
+            sh:path ositrace:usedDataSources ] ;
+    sh:targetClass ositrace:DataSource .
+
+ositrace:FormatShape a sh:NodeShape ;
+    sh:property [ skos:example "3.7.0" ;
+            sh:datatype xsd:string ;
+            sh:description "Version of data format"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of version failed!"@en ;
+            sh:name "version"@en ;
+            sh:order 1 ;
+            sh:path ositrace:version ],
+        [ skos:example "ASAM OSI GroundTruth; ASAM OSI SensorView; ASAM OSI SensorData" ;
+            sh:datatype xsd:string ;
+            sh:description "Format type definition"@en ;
+            sh:in ("ASAM OSI GroundTruth" "ASAM OSI SensorView" "ASAM OSI SensorData") ;
+            sh:maxCount 1 ;
+            sh:message "Validation of type failed!"@en ;
+            sh:name "type"@en ;
+            sh:order 0 ;
+            sh:path ositrace:type ] ;
+    sh:targetClass ositrace:Format .
+
+ositrace:QualityShape a sh:NodeShape ;
+    sh:property [ skos:example "0.1" ;
+            sh:datatype xsd:float ;
+            sh:description "Accuracy of traffic relevant objects, signs and signals"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of accuracySignals failed!"@en ;
+            sh:minCount 0 ;
+            sh:name "accuracySignals"@en ;
+            sh:order 3 ;
+            sh:path ositrace:accuracySignals ],
+        [ skos:example "0.1" ;
+            sh:datatype xsd:float ;
+            sh:description "Accuracy of objects in the traffic space, which do not directly affect the traffic"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of accuracyObjects failed!"@en ;
+            sh:minCount 0 ;
+            sh:name "accuracyObjects"@en ;
+            sh:order 4 ;
+            sh:path ositrace:accuracyObjects ],
+        [ skos:example "0.1" ;
+            sh:datatype xsd:float ;
+            sh:description "Accuracy lane modell height"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of accuracyLaneModelHeight failed!"@en ;
+            sh:minCount 0 ;
+            sh:name "accuracyLaneModelHeight"@en ;
+            sh:order 2 ;
+            sh:path ositrace:accuracyLaneModelHeight ],
+        [ skos:example "0.01" ;
+            sh:datatype xsd:float ;
+            sh:description "Precision of measured road network (relative accuracy)"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of precision failed!"@en ;
+            sh:minCount 0 ;
+            sh:name "precision"@en ;
+            sh:order 0 ;
+            sh:path ositrace:precision ],
+        [ skos:example "0.1" ;
+            sh:datatype xsd:float ;
+            sh:description "Accuracy of lane modell 2d"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of accuracyLaneModel2d failed!"@en ;
+            sh:minCount 0 ;
+            sh:name "accuracyLaneModel2d"@en ;
+            sh:order 1 ;
+            sh:path ositrace:accuracyLaneModel2d ],
+        [ skos:example "Calibration performed at origin" ;
+            sh:datatype xsd:string ;
+            sh:description "Description of any calibration steps performed prior to measurement"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of calibration failed!"@en ;
+            sh:minCount 0 ;
+            sh:name "calibration"@en ;
+            sh:order 5 ;
+            sh:path ositrace:calibration ] ;
+    sh:targetClass ositrace:Quality .
+
+ositrace:QuantityShape a sh:NodeShape ;
+    sh:property [ skos:example "1000" ;
+            sh:datatype xsd:unsignedInt ;
+            sh:description "Number of frames/messages in the trace file"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of numberFrames failed!"@en ;
+            sh:name "numberFrames"@en ;
+            sh:order 2 ;
+            sh:path ositrace:numberFrames ] ;
+    sh:targetClass ositrace:Quantity .
+
+ositrace:MovingObjectShape a sh:NodeShape ;
+    sh:property [ skos:example "42" ;
+            sh:datatype xsd:unsignedLong ;
+            sh:description "Moving object identifier in trace file"@en ;
+            sh:mincount 1 ;
+            sh:maxcount 1 ;
+            sh:message "Validation of identifier failed!"@en ;
+            sh:name "identifier"@en ;
+            sh:order 1 ;
+            sh:path ositrace:identifier ],
+        [ skos:example "PMSF Mercedes CLS Ego Vehicle" ;
+            sh:datatype xsd:string ;
+            sh:description "Description of moving object in the trace file"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of description failed!"@en ;
+            sh:name "description"@en ;
+            sh:order 2 ;
+            sh:path ositrace:description ] ;
+    sh:targetClass ositrace:MovingObject .
+
+ositrace:EventShape a sh:NodeShape ;
+    sh:property [ skos:example "2024-05-11T13:20:03.250320Z" ;
+            sh:datatype xsd:dateTimeStamp ;
+            sh:description "Exact timestamp of the event in the recorded trace"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of time failed!"@en ;
+            sh:minCount 1 ;
+            sh:name "time"@en ;
+            sh:order 1 ;
+            sh:path ositrace:time ],
+        [ skos:example "42" ;
+            sh:datatype xsd:string ;
+            sh:description "Unique tag of the event in trace file"@en ;
+            sh:mincount 1 ;
+            sh:maxcount 1 ;
+            sh:message "Validation of tag failed!"@en ;
+            sh:name "tag"@en ;
+            sh:order 2 ;
+            sh:path ositrace:tag ],
+        [ skos:example "Beginning of cut-in manoever" ;
+            sh:datatype xsd:string ;
+            sh:description "Description of event in the trace file"@en ;
+            sh:maxCount 1 ;
+            sh:message "Validation of description failed!"@en ;
+            sh:name "description"@en ;
+            sh:order 3 ;
+            sh:path ositrace:description ] ;
+    sh:targetClass ositrace:Event .

--- a/ositrace/ositrace_shacl.ttl
+++ b/ositrace/ositrace_shacl.ttl
@@ -232,7 +232,7 @@ ositrace:QuantityShape a sh:NodeShape ;
             sh:maxCount 1 ;
             sh:message "Validation of numberFrames failed!"@en ;
             sh:name "numberFrames"@en ;
-            sh:order 2 ;
+            sh:order 0 ;
             sh:path ositrace:numberFrames ] ;
     sh:targetClass ositrace:Quantity .
 


### PR DESCRIPTION
# Description

This is a pull request for the more generic handling of OSI Trace files - beyond the pure SensorData kind and application, as well as better alignment with other existing ontologies, like e.g. hdmap.

Resolves #21 

## Type of change

- [x] New type (non-breaking change which adds a type)

## How Has This Been Tested?

Example files have been created, see https://github.com/GAIA-X4PLC-AAD/sensordata/tree/main/ars548/sampledata/119_pmsf_adc_cutout .

## Checklist

- [x] My code follows the modelling guidelines of this project
- [x] I have performed a self-review of my own changes
