### PR TITLE
Fix naming of property

### DIFF
--- a/environment-model/VARIABLES.md
+++ b/environment-model/VARIABLES.md
@@ -14,7 +14,7 @@
 | EnvironmentModelShape | environment-model | project | 1 | 1 |  |  | environment-model_shacl.ttl |
 | EnvironmentModelShape | environment-model | format | 1 | 1 |  |  | environment-model_shacl.ttl |
 | EnvironmentModelShape | environment-model | georeference | 0 | 1 |  |  | environment-model_shacl.ttl |
-| FormatShape | environment-model | dataType |  | 1 | Data type definition | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |
+| FormatShape | environment-model | formatType |  | 1 | Data type definition | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |
 | FormatShape | environment-model | version |  | 1 | Version of data format | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |
 | ProjectShape | environment-model | creationVersion |  | 1 | Tool for the creation of the data | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |
 | ProjectShape | environment-model | creationSource |  | 1 | Tool for the creation of the data | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |

--- a/environment-model/environment-model_instance.json
+++ b/environment-model/environment-model_instance.json
@@ -129,7 +129,7 @@
   },
   "environment-model:format": {
     "@type": "environment-model:Format",
-    "environment-model:dataType": "Unreal DataSmith",
+    "environment-model:formatType": "Unreal DataSmith",
     "environment-model:version": {
       "@value": "SDK 4.25",
       "@type": "xsd:string"

--- a/environment-model/environment-model_shacl.ttl
+++ b/environment-model/environment-model_shacl.ttl
@@ -44,10 +44,10 @@ environment-model:FormatShape a sh:NodeShape ;
             sh:description "Data type definition"@en ;
             sh:in ("Autodesk FBX" "GLTF" "OpenSceneGraph" "Unreal DataSmith") ;
             sh:maxCount 1 ;
-            sh:message "Validation of dataType failed!"@en ;
-            sh:name "dataType"@en ;
+            sh:message "Validation of type failed!"@en ;
+            sh:name "type"@en ;
             sh:order 0 ;
-            sh:path environment-model:dataType ],
+            sh:path environment-model:formatType ],
         [ skos:example "SDK 4.25" ;
             sh:datatype xsd:string ;
             sh:description "Version of data format"@en ;

--- a/hdmap/VARIABLES.md
+++ b/hdmap/VARIABLES.md
@@ -22,7 +22,7 @@
 | DataSourceShape | hdmap | measurementSystem |  | 1 | Main acquisition device | <http://www.w3.org/2001/XMLSchema#string> | hdmap_shacl.ttl |
 | DataSourceShape | hdmap | usedDataSources |  |  | Basic data for the creation of the map | <http://www.w3.org/2001/XMLSchema#string> | hdmap_shacl.ttl |
 | FormatShape | hdmap | version |  | 1 | Version of data format | <http://www.w3.org/2001/XMLSchema#string> | hdmap_shacl.ttl |
-| FormatShape | hdmap | type |  | 1 | Format type definition | <http://www.w3.org/2001/XMLSchema#string> | hdmap_shacl.ttl |
+| FormatShape | hdmap | formatType |  | 1 | Format type definition | <http://www.w3.org/2001/XMLSchema#string> | hdmap_shacl.ttl |
 | QualityShape | hdmap | accuracySignals | 0 | 1 | Accuracy of traffic relevant objects, signs and signals | <http://www.w3.org/2001/XMLSchema#float> | hdmap_shacl.ttl |
 | QualityShape | hdmap | accuracyObjects | 0 | 1 | Accuracy of objects in the traffic space, which do not directly affect the traffic | <http://www.w3.org/2001/XMLSchema#float> | hdmap_shacl.ttl |
 | QualityShape | hdmap | accuracyLaneModelHeight | 0 | 1 | Accuracy lane modell height | <http://www.w3.org/2001/XMLSchema#float> | hdmap_shacl.ttl |

--- a/hdmap/hdmap_instance.json
+++ b/hdmap/hdmap_instance.json
@@ -98,7 +98,7 @@
   },
   "hdmap:format": {
     "@type": "hdmap:Format",
-    "hdmap:type": "ASAM OpenDRIVE",
+    "hdmap:formatType": "ASAM OpenDRIVE",
     "hdmap:version": {
       "@value": "1.6",
       "@type": "xsd:string"

--- a/hdmap/hdmap_shacl.ttl
+++ b/hdmap/hdmap_shacl.ttl
@@ -45,7 +45,7 @@ hdmap:HdMapShape a sh:NodeShape ;
     sh:targetClass hdmap:HdMap .
 
 hdmap:ContentShape a sh:NodeShape ;
-    sh:property [ skos:example "[motorway, residential]" ;
+    sh:property [ skos:example "[Motorway, Rural]" ;
             sh:datatype xsd:string ;
             sh:description "Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3"@en ;
             sh:in ("Bicycle" "LowSpeed" "Motorway" "Pedestrian" "Rural" "Town" "TownArterial" "TownCollector" "TownExpressway" "TownLocal" "TownPlayStreet" "TownPrivate" "Unknown") ;

--- a/hdmap/hdmap_shacl.ttl
+++ b/hdmap/hdmap_shacl.ttl
@@ -115,7 +115,7 @@ hdmap:FormatShape a sh:NodeShape ;
             sh:message "Validation of type failed!"@en ;
             sh:name "type"@en ;
             sh:order 0 ;
-            sh:path hdmap:type ] ;
+            sh:path hdmap:formatType ] ;
     sh:targetClass hdmap:Format .
 
 hdmap:QualityShape a sh:NodeShape ;

--- a/ositrace/VARIABLES.md
+++ b/ositrace/VARIABLES.md
@@ -29,7 +29,7 @@
 | DataSourceShape | ositrace | measurementSystem |  | 1 | Main acquisition device | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
 | DataSourceShape | ositrace | usedDataSources |  |  | Basic data for the creation of the trace  | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
 | FormatShape | ositrace | version |  | 1 | Version of data format | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
-| FormatShape | ositrace | type |  | 1 | Format type definition | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
+| FormatShape | ositrace | formatType |  | 1 | Format type definition | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
 | QualityShape | ositrace | accuracySignals | 0 | 1 | Accuracy of traffic relevant objects, signs and signals | <http://www.w3.org/2001/XMLSchema#float> | ositrace_shacl.ttl |
 | QualityShape | ositrace | accuracyObjects | 0 | 1 | Accuracy of objects in the traffic space, which do not directly affect the traffic | <http://www.w3.org/2001/XMLSchema#float> | ositrace_shacl.ttl |
 | QualityShape | ositrace | accuracyLaneModelHeight | 0 | 1 | Accuracy lane modell height | <http://www.w3.org/2001/XMLSchema#float> | ositrace_shacl.ttl |

--- a/ositrace/ositrace_instance.json
+++ b/ositrace/ositrace_instance.json
@@ -71,7 +71,7 @@
   },
   "ositrace:format": {
     "@type": "ositrace:Format",
-    "ositrace:type": "ASAM OSI SensorData",
+    "ositrace:formatType": "ASAM OSI SensorData",
     "ositrace:version": {
       "@value": "3.6.0/3.20.0",
       "@type": "xsd:string"

--- a/ositrace/ositrace_shacl.ttl
+++ b/ositrace/ositrace_shacl.ttl
@@ -165,7 +165,7 @@ ositrace:FormatShape a sh:NodeShape ;
             sh:message "Validation of type failed!"@en ;
             sh:name "type"@en ;
             sh:order 0 ;
-            sh:path ositrace:type ] ;
+            sh:path ositrace:formatType ] ;
     sh:targetClass ositrace:Format .
 
 ositrace:QualityShape a sh:NodeShape ;

--- a/scenario/VARIABLES.md
+++ b/scenario/VARIABLES.md
@@ -20,7 +20,7 @@
 | ScenarioShape | georeference | georeference | 0 | 1 |  |  | scenario_shacl.ttl |
 | DataSourceShape | scenario | source | 0 | 1 | Capture type | <http://www.w3.org/2001/XMLSchema#string> | scenario_shacl.ttl |
 | EnvironmentalShape | scenario | sunAzimuth | 0 |  | Azimuth of the sun | <http://www.w3.org/2001/XMLSchema#float> | scenario_shacl.ttl |
-| FormatShape | scenario | dataFormat |  | 1 | Format type definition | <http://www.w3.org/2001/XMLSchema#string> | scenario_shacl.ttl |
+| FormatShape | scenario | formatType |  | 1 | Format type definition | <http://www.w3.org/2001/XMLSchema#string> | scenario_shacl.ttl |
 | FormatShape | scenario | version |  | 1 | Version of data format | <http://www.w3.org/2001/XMLSchema#string> | scenario_shacl.ttl |
 | ScenarioCommonShape | scenario | abstractionLevel |  | 1 | Pegasus type of scenario | <http://www.w3.org/2001/XMLSchema#string> | scenario_shacl.ttl |
 | ScenarioCommonShape | scenario | timeDate | 0 | 1 | Time of the scenario if applicaple. Either time of recording or if synthetic the time it happens. | <http://www.w3.org/2001/XMLSchema#dateTime> | scenario_shacl.ttl |

--- a/scenario/scenario_instance.json
+++ b/scenario/scenario_instance.json
@@ -96,7 +96,7 @@
   },
   "scenario:format": {
     "@type": "scenario:Format",
-    "scenario:dataFormat": "ASAM OpenSCENARIO",
+    "scenario:formatType": "ASAM OpenSCENARIO",
     "scenario:version": {
       "@value": "1.2",
       "@type": "xsd:string"

--- a/scenario/scenario_shacl.ttl
+++ b/scenario/scenario_shacl.ttl
@@ -83,9 +83,9 @@ scenario:FormatShape a sh:NodeShape ;
             sh:in ("ASAM OpenSCENARIO") ;
             sh:maxCount 1 ;
             sh:message "Validation of type failed!"@en ;
-            sh:name "dataFormat"@en ;
+            sh:name "type"@en ;
             sh:order 0 ;
-            sh:path scenario:dataFormat ],
+            sh:path scenario:formatType ],
         [ skos:example "1.5" ;
             sh:datatype xsd:string ;
             sh:description "Version of data format"@en ;


### PR DESCRIPTION
# Description

fix Naming of property format type constistent through all shapes
https://github.com/GAIA-X4PLC-AAD/ontology-management-base/issues/89
use now formatType

## Type of change

Please delete options that are not relevant.

- [ ] New type (non-breaking change which adds a type)
- [ ] Change (non-breaking change or fix on an existing type)
- [ ] Breaking change (Change that would cause existing Self Descriptions not to be accepted anymore by a Federated Catalogue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any
relevant details for your test configuration

- Test A
- Test B

## Checklist

- [ ] My code follows the modelling guidelines of this project
- [ ] I have performed a self-review of my own changes
