### PR TITLE
93 generalgeneral should not be a subclass of gxdataresource

### DIFF
--- a/general/general_ontology.ttl
+++ b/general/general_ontology.ttl
@@ -14,7 +14,6 @@ general: a owl:Ontology ;
 general:General a owl:Class ;
     rdfs:label "Class definition for General" ;
     rdfs:comment "General attributes for all assets"@en ;
-    rdfs:subClassOf gx:DataResource .
 
 general:Description a owl:Class ;
     rdfs:label "Description definition for General" ;

--- a/georeference/georeference_ontology.ttl
+++ b/georeference/georeference_ontology.ttl
@@ -14,7 +14,6 @@ georeference: a owl:Ontology ;
 georeference:Georeference a owl:Class ;
     rdfs:label "class definition for Georeference" ;
     rdfs:comment "Attributes for location and georeference information"@en ;
-    rdfs:subClassOf gx:DataResource .
 
 georeference:GeodeticReferenceSystem a owl:Class ;
     rdfs:label "class definition for GeodeticReferenceSystem" ;


### PR DESCRIPTION
# Description

remove subClassOf gx:DataResource  in general and georeference

## Type of change

Please delete options that are not relevant.

- [ ] New type (non-breaking change which adds a type)
- [ ] Change (non-breaking change or fix on an existing type)
- [ ] Breaking change (Change that would cause existing Self Descriptions not to be accepted anymore by a Federated Catalogue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any
relevant details for your test configuration

- Test A
- Test B

## Checklist

- [ ] My code follows the modelling guidelines of this project
- [ ] I have performed a self-review of my own changes
