### PR TITLE
87 missing shname und shproperty in properties with shnode

### DIFF
--- a/environment-model/VARIABLES.md
+++ b/environment-model/VARIABLES.md
@@ -8,12 +8,12 @@
 
 | Shape | Property prefix | Property | MinCount | MaxCount | Description | Datatype/NodeKind | Filename |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| EnvironmentModelShape | environment-model | general | 1 | 1 |  |  | environment-model_shacl.ttl |
-| EnvironmentModelShape | environment-model | quantity | 1 | 1 |  |  | environment-model_shacl.ttl |
-| EnvironmentModelShape | environment-model | quality | 1 | 1 |  |  | environment-model_shacl.ttl |
-| EnvironmentModelShape | environment-model | project | 1 | 1 |  |  | environment-model_shacl.ttl |
-| EnvironmentModelShape | environment-model | format | 1 | 1 |  |  | environment-model_shacl.ttl |
-| EnvironmentModelShape | environment-model | georeference | 0 | 1 |  |  | environment-model_shacl.ttl |
+| EnvironmentModelShape | environment-model | general | 1 | 1 | general object with properties for description, data, links, bundles |  | environment-model_shacl.ttl |
+| EnvironmentModelShape | environment-model | quantity | 1 | 1 | quantity object with properties for quatity values |  | environment-model_shacl.ttl |
+| EnvironmentModelShape | environment-model | quality | 1 | 1 | quality object with properties for quality values |  | environment-model_shacl.ttl |
+| EnvironmentModelShape | environment-model | project | 1 | 1 | project object with properties for project informations |  | environment-model_shacl.ttl |
+| EnvironmentModelShape | environment-model | format | 1 | 1 | format object with properties for format informations |  | environment-model_shacl.ttl |
+| EnvironmentModelShape | environment-model | georeference | 0 | 1 | georeference object with properties for georeference informations |  | environment-model_shacl.ttl |
 | FormatShape | environment-model | dataType |  | 1 | Data type definition | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |
 | FormatShape | environment-model | version |  | 1 | Version of data format | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |
 | ProjectShape | environment-model | creationVersion |  | 1 | Tool for the creation of the data | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |

--- a/environment-model/VARIABLES.md
+++ b/environment-model/VARIABLES.md
@@ -14,7 +14,7 @@
 | EnvironmentModelShape | environment-model | project | 1 | 1 | project object with properties for project informations |  | environment-model_shacl.ttl |
 | EnvironmentModelShape | environment-model | format | 1 | 1 | format object with properties for format informations |  | environment-model_shacl.ttl |
 | EnvironmentModelShape | environment-model | georeference | 0 | 1 | georeference object with properties for georeference informations |  | environment-model_shacl.ttl |
-| FormatShape | environment-model | dataType |  | 1 | Data type definition | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |
+| FormatShape | environment-model | formatType |  | 1 | Data type definition | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |
 | FormatShape | environment-model | version |  | 1 | Version of data format | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |
 | ProjectShape | environment-model | creationVersion |  | 1 | Tool for the creation of the data | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |
 | ProjectShape | environment-model | creationSource |  | 1 | Tool for the creation of the data | <http://www.w3.org/2001/XMLSchema#string> | environment-model_shacl.ttl |

--- a/environment-model/environment-model_shacl.ttl
+++ b/environment-model/environment-model_shacl.ttl
@@ -9,31 +9,43 @@ environment-model:EnvironmentModelShape a sh:NodeShape ;
     sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
+            sh:name "generalObject" ;
+            sh:description "general object with properties for description, data, links, bundles" ;
             sh:order 1 ;
             sh:path environment-model:general ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node environment-model:QuantityShape ;
+            sh:name "quantityObject" ;
+            sh:description "quantity object with properties for quatity values" ;
             sh:order 2 ;
             sh:path environment-model:quantity ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node environment-model:QualityShape ;
+            sh:name "qualityObject" ;
+            sh:description "quality object with properties for quality values" ;
             sh:order 3 ;
             sh:path environment-model:quality ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node environment-model:ProjectShape ;
+            sh:name "projectObject" ;
+            sh:description "project object with properties for project informations" ;
             sh:order 4 ;
             sh:path environment-model:project ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node environment-model:FormatShape ;
+            sh:name "formatObject" ;
+            sh:description "format object with properties for format informations" ;
             sh:order 5 ;
             sh:path environment-model:format ],
         [ sh:maxCount 1 ;
             sh:minCount 0 ;            
             sh:node georeference:GeoreferenceShape ;
+            sh:name "georeferenceObject" ;
+            sh:description "georeference object with properties for georeference informations" ;
             sh:order 6 ;
             sh:path environment-model:georeference ] ;
     sh:targetClass environment-model:EnvironmentModel .   

--- a/general/VARIABLES.md
+++ b/general/VARIABLES.md
@@ -9,10 +9,10 @@
 
 | Shape | Property prefix | Property | MinCount | MaxCount | Description | Datatype/NodeKind | Filename |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| GeneralShape | general | description | 1 | 1 |  |  | general_shacl.ttl |
-| GeneralShape | general | data | 1 | 1 |  |  | general_shacl.ttl |
-| GeneralShape | general | links | 1 | 1 |  |  | general_shacl.ttl |
-| GeneralShape | general | bundleData | 1 | 1 |  |  | general_shacl.ttl |
+| GeneralShape | general | description | 1 | 1 | description object with property for name and description |  | general_shacl.ttl |
+| GeneralShape | general | data | 1 | 1 | data object with property for size, id and record time |  | general_shacl.ttl |
+| GeneralShape | general | links | 1 | 1 | link object with links to asset and media files |  | general_shacl.ttl |
+| GeneralShape | general | bundleData | 1 | 1 | bundle object with links to required and optional related data |  | general_shacl.ttl |
 | DescriptionShape | gx | name | 1 | 1 | A human readable name of the entity. | <http://www.w3.org/2001/XMLSchema#string> | general_shacl.ttl |
 | DescriptionShape | gx | description | 1 | 1 | A free text description of the entity. | <http://www.w3.org/2001/XMLSchema#string> | general_shacl.ttl |
 | DataShape | general | size | 1 | 1 | Size of the file to be downloaded in MB. | <http://www.w3.org/2001/XMLSchema#float> | general_shacl.ttl |

--- a/general/VARIABLES.md
+++ b/general/VARIABLES.md
@@ -12,7 +12,7 @@
 | GeneralShape | general | description | 1 | 1 | description object with property for name and description |  | general_shacl.ttl |
 | GeneralShape | general | data | 1 | 1 | data object with property for size, id and record time |  | general_shacl.ttl |
 | GeneralShape | general | links | 1 | 1 | link object with links to asset and media files |  | general_shacl.ttl |
-| GeneralShape | general | bundleData | 1 | 1 | bundle object with links to required and optional related data |  | general_shacl.ttl |
+| GeneralShape | general | bundleData |  | 1 | bundle object with links to required and optional related data |  | general_shacl.ttl |
 | DescriptionShape | gx | name | 1 | 1 | A human readable name of the entity. | <http://www.w3.org/2001/XMLSchema#string> | general_shacl.ttl |
 | DescriptionShape | gx | description | 1 | 1 | A free text description of the entity. | <http://www.w3.org/2001/XMLSchema#string> | general_shacl.ttl |
 | DataShape | general | size | 1 | 1 | Size of the file to be downloaded in MB. | <http://www.w3.org/2001/XMLSchema#float> | general_shacl.ttl |

--- a/general/general_shacl.ttl
+++ b/general/general_shacl.ttl
@@ -8,21 +8,29 @@ general:GeneralShape a sh:NodeShape ;
     sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:DescriptionShape ;
+            sh:name "descriptionObject" ;
+            sh:description "description object with property for name and description" ;
             sh:order 1 ;
             sh:path general:description ],     
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:DataShape ;
+            sh:name "dataObject" ;
+            sh:description "data object with property for size, id and record time" ;
             sh:order 2 ;
             sh:path general:data ],               
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:LinksShape ;
+            sh:name "linkObject" ;
+            sh:description "link object with links to asset and media files" ;
             sh:order 3 ;
             sh:path general:links ],         
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:BundleDataShape ;
+            sh:name "bundleObject" ;
+            sh:description "bundle object with links to required and optional related data" ;
             sh:order 4 ;
             sh:path general:bundleData ];
     sh:targetClass general:General .

--- a/georeference/VARIABLES.md
+++ b/georeference/VARIABLES.md
@@ -8,8 +8,8 @@
 
 | Shape | Property prefix | Property | MinCount | MaxCount | Description | Datatype/NodeKind | Filename |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| GeoreferenceShape | georeference | projectLocation | 1 | 1 |  |  | georeference_shacl.ttl |
-| GeoreferenceShape | georeference | geodeticReferenceSystem | 1 | 1 |  |  | georeference_shacl.ttl |
+| GeoreferenceShape | georeference | projectLocation | 1 | 1 | projectLocation object with property for locations and description |  | georeference_shacl.ttl |
+| GeoreferenceShape | georeference | geodeticReferenceSystem | 1 | 1 | geodeticReferenceSystem object with properties for projection informations |  | georeference_shacl.ttl |
 | GeodeticReferenceSystemShape | georeference | origin | 1 | 1 | World coordinates of map origin |  | georeference_shacl.ttl |
 | GeodeticReferenceSystemShape | georeference | coordinateSystem | 0 | 1 | EPSG code of the map | <http://www.w3.org/2001/XMLSchema#string> | georeference_shacl.ttl |
 | GeodeticReferenceSystemShape | georeference | heightSystem |  | 1 | Ellipsodial height or orthometric height | <http://www.w3.org/2001/XMLSchema#string> | georeference_shacl.ttl |

--- a/georeference/georeference_shacl.ttl
+++ b/georeference/georeference_shacl.ttl
@@ -7,11 +7,15 @@ georeference:GeoreferenceShape a sh:NodeShape ;
     sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node georeference:ProjectLocationShape ;
+            sh:name "projectLocationObject" ;
+            sh:description "projectLocation object with property for locations and description" ;
             sh:order 0 ;
             sh:path georeference:projectLocation ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node georeference:GeodeticReferenceSystemShape ;
+            sh:name "geodeticReferenceSystemObject" ;
+            sh:description "geodeticReferenceSystem object with properties for projection informations" ;
             sh:order 1 ;
             sh:path georeference:geodeticReferenceSystem ] ;
     sh:targetClass georeference:Georeference .

--- a/hdmap/VARIABLES.md
+++ b/hdmap/VARIABLES.md
@@ -8,13 +8,13 @@
 
 | Shape | Property prefix | Property | MinCount | MaxCount | Description | Datatype/NodeKind | Filename |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| HdMapShape | hdmap | general | 1 | 1 |  |  | hdmap_shacl.ttl |
-| HdMapShape | hdmap | format | 1 | 1 |  |  | hdmap_shacl.ttl |
-| HdMapShape | hdmap | content | 1 | 1 |  |  | hdmap_shacl.ttl |
-| HdMapShape | hdmap | quantity | 1 | 1 |  |  | hdmap_shacl.ttl |
-| HdMapShape | hdmap | quality | 1 | 1 |  |  | hdmap_shacl.ttl |
-| HdMapShape | hdmap | dataSource | 1 | 1 |  |  | hdmap_shacl.ttl |
-| HdMapShape | hdmap | georeference | 1 | 1 |  |  | hdmap_shacl.ttl |
+| HdMapShape | hdmap | general | 1 | 1 | general object with properties for descriptions, data, links, bundle |  | hdmap_shacl.ttl |
+| HdMapShape | hdmap | format | 1 | 1 | format object with properties for format informations |  | hdmap_shacl.ttl |
+| HdMapShape | hdmap | content | 1 | 1 | content object with properties for road types, lane type, object type and traffic direction |  | hdmap_shacl.ttl |
+| HdMapShape | hdmap | quantity | 1 | 1 | quantity object with properties for quantity informations |  | hdmap_shacl.ttl |
+| HdMapShape | hdmap | quality | 1 | 1 | quality object with properties for quality informations |  | hdmap_shacl.ttl |
+| HdMapShape | hdmap | dataSource | 1 | 1 | dataSource object with properties for data sources |  | hdmap_shacl.ttl |
+| HdMapShape | hdmap | georeference | 1 | 1 | georeference object with properties for georeference informations |  | hdmap_shacl.ttl |
 | ContentShape | hdmap | roadTypes |  |  | Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3 | <http://www.w3.org/2001/XMLSchema#string> | hdmap_shacl.ttl |
 | ContentShape | hdmap | laneTypes |  |  | Covered lane types, see ODR spec section 9.5.3. | <http://www.w3.org/2001/XMLSchema#string> | hdmap_shacl.ttl |
 | ContentShape | hdmap | levelOfDetail |  |  | Covered object classes, see ODR spec section 11 | <http://www.w3.org/2001/XMLSchema#string> | hdmap_shacl.ttl |

--- a/hdmap/hdmap_shacl.ttl
+++ b/hdmap/hdmap_shacl.ttl
@@ -10,36 +10,50 @@ hdmap:HdMapShape a sh:NodeShape ;
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
+            sh:name "generalObject" ;
+            sh:description "general object with properties for descriptions, data, links, bundle" ;
             sh:order 1 ;
             sh:path hdmap:general ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node hdmap:FormatShape ;
+            sh:name "formatObject" ;
+            sh:description "format object with properties for format informations" ;
             sh:order 2 ;
             sh:path hdmap:format ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node hdmap:ContentShape ;
+            sh:name "contentObject" ;
+            sh:description "content object with properties for road types, lane type, object type and traffic direction" ;
             sh:order 3 ;
             sh:path hdmap:content ],            
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node hdmap:QuantityShape ;
+            sh:name "quantityObject" ;
+            sh:description "quantity object with properties for quantity informations" ;
             sh:order 4 ;
             sh:path hdmap:quantity ],            
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node hdmap:QualityShape ;
+            sh:name "qualityObject" ;
+            sh:description "quality object with properties for quality informations" ;
             sh:order 5 ;
             sh:path hdmap:quality ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node hdmap:DataSourceShape ;
+            sh:name "dataSourceObject" ;
+            sh:description "dataSource object with properties for data sources" ;
             sh:order 6 ;
             sh:path hdmap:dataSource ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node georeference:GeoreferenceShape ;
+            sh:name "georeferenceObject" ;
+            sh:description "georeference object with properties for georeference informations" ;
             sh:order 7 ;
             sh:path hdmap:georeference ] ;
     sh:targetClass hdmap:HdMap .

--- a/ositrace/VARIABLES.md
+++ b/ositrace/VARIABLES.md
@@ -8,13 +8,13 @@
 
 | Shape | Property prefix | Property | MinCount | MaxCount | Description | Datatype/NodeKind | Filename |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| OSITraceShape | ositrace | general | 1 | 1 |  |  | ositrace_shacl.ttl |
-| OSITraceShape | ositrace | format | 1 | 1 |  |  | ositrace_shacl.ttl |
-| OSITraceShape | ositrace | content | 1 | 1 |  |  | ositrace_shacl.ttl |
-| OSITraceShape | ositrace | quality | 1 | 1 |  |  | ositrace_shacl.ttl |
-| OSITraceShape | ositrace | quantity | 1 | 1 |  |  | ositrace_shacl.ttl |
-| OSITraceShape | ositrace | dataSource | 1 | 1 |  |  | ositrace_shacl.ttl |
-| OSITraceShape | ositrace | georeference | 1 | 1 |  |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | general | 1 | 1 | general object with properties for descriptions, data, links, bundle |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | format | 1 | 1 | format object with properties for format informations |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | content | 1 | 1 | content object with properties for road types, lane type, object type and traffic direction |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | quality | 1 | 1 | quality object with properties for quality informations |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | quantity | 1 | 1 | quantity object with properties for quantity informations |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | dataSource | 1 | 1 | dataSource object with properties for data sources |  | ositrace_shacl.ttl |
+| OSITraceShape | ositrace | georeference | 1 | 1 | georeference object with properties for georeference informations |  | ositrace_shacl.ttl |
 | ContentShape | ositrace | roadTypes |  |  | Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3 | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
 | ContentShape | ositrace | laneTypes |  |  | Covered lane types, see ODR spec section 9.5.3. | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |
 | ContentShape | ositrace | levelOfDetail |  |  | Covered object classes, see ODR spec section 11 | <http://www.w3.org/2001/XMLSchema#string> | ositrace_shacl.ttl |

--- a/ositrace/ositrace_shacl.ttl
+++ b/ositrace/ositrace_shacl.ttl
@@ -10,36 +10,50 @@ ositrace:OSITraceShape a sh:NodeShape ;
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
+            sh:name "generalObject" ;
+            sh:description "general object with properties for descriptions, data, links, bundle" ;
             sh:order 1 ;
             sh:path ositrace:general ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node ositrace:FormatShape ;
+            sh:name "formatObject" ;
+            sh:description "format object with properties for format informations" ;
             sh:order 2 ;
             sh:path ositrace:format ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node ositrace:ContentShape ;
+            sh:name "contentObject" ;
+            sh:description "content object with properties for road types, lane type, object type and traffic direction" ;
             sh:order 3 ;
             sh:path ositrace:content ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node ositrace:QualityShape ;
+            sh:name "qualityObject" ;
+            sh:description "quality object with properties for quality informations" ; 
             sh:order 4 ;
             sh:path ositrace:quality ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node ositrace:QuantityShape ;
+            sh:name "quantityObject" ;
+            sh:description "quantity object with properties for quantity informations" ;	
             sh:order 5 ;
             sh:path ositrace:quantity ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node ositrace:DataSourceShape ;
+            sh:name "dataSourceObject" ;
+            sh:description "dataSource object with properties for data sources" ;
             sh:order 6 ;
             sh:path ositrace:dataSource ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:node georeference:GeoreferenceShape ;
+            sh:node georeference:GeoreferenceShape ;            
+            sh:name "georeferenceObject" ;
+            sh:description "georeference object with properties for georeference informations" ;
             sh:order 7 ;
             sh:path ositrace:georeference ] ;
     sh:targetClass ositrace:OSITrace .

--- a/scenario/VARIABLES.md
+++ b/scenario/VARIABLES.md
@@ -9,15 +9,15 @@
 
 | Shape | Property prefix | Property | MinCount | MaxCount | Description | Datatype/NodeKind | Filename |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| ScenarioShape | scenario | general | 1 | 1 |  |  | scenario_shacl.ttl |
-| ScenarioShape | scenario | environmental | 1 | 1 |  |  | scenario_shacl.ttl |
-| ScenarioShape | scenario | common | 1 | 1 |  |  | scenario_shacl.ttl |
-| ScenarioShape | scenario | source | 1 | 1 |  |  | scenario_shacl.ttl |
-| ScenarioShape | scenario | structural | 1 | 1 |  |  | scenario_shacl.ttl |
-| ScenarioShape | scenario | traffic | 1 | 1 |  |  | scenario_shacl.ttl |
-| ScenarioShape | scenario | trafficParticipants | 1 | 1 |  |  | scenario_shacl.ttl |
-| ScenarioShape | scenario | format | 1 | 1 |  |  | scenario_shacl.ttl |
-| ScenarioShape | georeference | georeference | 0 | 1 |  |  | scenario_shacl.ttl |
+| ScenarioShape | scenario | general | 1 | 1 | general object with properties for descriptions, data, links, bundle |  | scenario_shacl.ttl |
+| ScenarioShape | scenario | environmental | 1 | 1 | environmental object with property for sunAzimuth |  | scenario_shacl.ttl |
+| ScenarioShape | scenario | common | 1 | 1 | common object with property for common values |  | scenario_shacl.ttl |
+| ScenarioShape | scenario | source | 1 | 1 | source object with properties for data sources |  | scenario_shacl.ttl |
+| ScenarioShape | scenario | structural | 1 | 1 | structural object with links to dependend data |  | scenario_shacl.ttl |
+| ScenarioShape | scenario | traffic | 1 | 1 | traffic object with properties for country specific informations |  | scenario_shacl.ttl |
+| ScenarioShape | scenario | trafficParticipants | 1 | 1 | trafficParticipants object with properties for traffic participants |  | scenario_shacl.ttl |
+| ScenarioShape | scenario | format | 1 | 1 | format object with properties for format informations |  | scenario_shacl.ttl |
+| ScenarioShape | georeference | georeference | 0 | 1 | georeference object with properties for georeference informations |  | scenario_shacl.ttl |
 | DataSourceShape | scenario | source | 0 | 1 | Capture type | <http://www.w3.org/2001/XMLSchema#string> | scenario_shacl.ttl |
 | EnvironmentalShape | scenario | sunAzimuth | 0 |  | Azimuth of the sun | <http://www.w3.org/2001/XMLSchema#float> | scenario_shacl.ttl |
 | FormatShape | scenario | dataFormat |  | 1 | Format type definition | <http://www.w3.org/2001/XMLSchema#string> | scenario_shacl.ttl |

--- a/scenario/scenario_shacl.ttl
+++ b/scenario/scenario_shacl.ttl
@@ -9,46 +9,64 @@ scenario:ScenarioShape a sh:NodeShape ;
     sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
+            sh:name "generalObject" ;
+            sh:description "general object with properties for descriptions, data, links, bundle" ;
             sh:order 5 ;
             sh:path scenario:general ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node scenario:EnvironmentalShape ;
+            sh:name "environmentalObject" ;
+            sh:description "environmental object with property for sunAzimuth" ;
             sh:order 2 ;
             sh:path scenario:environmental ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node scenario:ScenarioCommonShape ;
+            sh:name "commonObject" ;
+            sh:description "common object with property for common values" ;
             sh:order 0 ;
             sh:path scenario:common ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node scenario:DataSourceShape ;
+            sh:name "sourceObject" ;
+            sh:description "source object with properties for data sources" ;
             sh:order 6 ;
             sh:path scenario:source ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node scenario:StructuralShape ;
+            sh:name "structuralObject" ;
+            sh:description "structural object with links to dependend data" ;
             sh:order 4 ;
             sh:path scenario:structural ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node scenario:TrafficShape ;
+            sh:name "trafficObject" ;
+            sh:description "traffic object with properties for country specific informations" ;
             sh:order 3 ;
             sh:path scenario:traffic ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node scenario:TrafficParticipantsShape ;
+            sh:name "trafficParticipantsObject" ;
+            sh:description "trafficParticipants object with properties for traffic participants" ;
             sh:order 1 ;
             sh:path scenario:trafficParticipants ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node scenario:FormatShape ;
+            sh:name "formatObject" ;
+            sh:description "format object with properties for format informations" ;
             sh:order 5 ;
             sh:path scenario:format ],
         [ sh:maxCount 1 ;
             sh:minCount 0 ;
             sh:node georeference:GeoreferenceShape ;
+            sh:name "georeferenceObject" ;
+            sh:description "georeference object with properties for georeference informations" ;
             sh:order 7 ;
             sh:path georeference:georeference ] ;
     sh:targetClass scenario:scenario .

--- a/surface-model/VARIABLES.md
+++ b/surface-model/VARIABLES.md
@@ -8,12 +8,12 @@
 
 | Shape | Property prefix | Property | MinCount | MaxCount | Description | Datatype/NodeKind | Filename |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| SurfaceModelShape | surface-model | general | 1 | 1 |  |  | surface-model_shacl.ttl |
-| SurfaceModelShape | surface-model | Format | 1 | 1 |  |  | surface-model_shacl.ttl |
-| SurfaceModelShape | surface-model | Data | 1 | 1 |  |  | surface-model_shacl.ttl |
-| SurfaceModelShape | surface-model | Quality | 1 | 1 |  |  | surface-model_shacl.ttl |
-| SurfaceModelShape | surface-model | Quantity | 1 | 1 |  |  | surface-model_shacl.ttl |
-| SurfaceModelShape | surface-model | Georeference | 1 | 1 |  |  | surface-model_shacl.ttl |
+| SurfaceModelShape | surface-model | general | 1 | 1 | general object with properties for descriptions, data, links, bundle |  | surface-model_shacl.ttl |
+| SurfaceModelShape | surface-model | Format | 1 | 1 | format object with properties for format informations |  | surface-model_shacl.ttl |
+| SurfaceModelShape | surface-model | Data | 1 | 1 | Data object with property for type of data |  | surface-model_shacl.ttl |
+| SurfaceModelShape | surface-model | Quality | 1 | 1 | quality object with properties for quality informations |  | surface-model_shacl.ttl |
+| SurfaceModelShape | surface-model | Quantity | 1 | 1 | quantity object with properties for quantity informations |  | surface-model_shacl.ttl |
+| SurfaceModelShape | surface-model | Georeference | 1 | 1 | georeference object with properties for georeference informations |  | surface-model_shacl.ttl |
 | DataShape | surface-model | dataType |  | 1 | Height, friction values, grey values | <http://www.w3.org/2001/XMLSchema#string> | surface-model_shacl.ttl |
 | FormatShape | surface-model | formatType |  | 1 | Format type definition | <http://www.w3.org/2001/XMLSchema#string> | surface-model_shacl.ttl |
 | FormatShape | surface-model | version |  | 1 | Version of data format | <http://www.w3.org/2001/XMLSchema#string> | surface-model_shacl.ttl |

--- a/surface-model/surface-model_shacl.ttl
+++ b/surface-model/surface-model_shacl.ttl
@@ -9,31 +9,43 @@ surface-model:SurfaceModelShape a sh:NodeShape ;
     sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
+            sh:name "generalObject" ;
+            sh:description "general object with properties for descriptions, data, links, bundle" ;
             sh:order 1 ;
             sh:path surface-model:general ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node surface-model:FormatShape ;
+            sh:name "formatObject" ;
+            sh:description "format object with properties for format informations" ;
             sh:order 2 ;
             sh:path surface-model:Format ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node surface-model:DataShape ;
+            sh:name "DataObject" ;
+            sh:description "Data object with property for type of data" ;
             sh:order 3 ;
             sh:path surface-model:Data ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node surface-model:QualityShape ;
+            sh:name "qualityObject" ;
+            sh:description "quality object with properties for quality informations" ;
             sh:order 4 ;
             sh:path surface-model:Quality ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node surface-model:QuantityShape ;
+            sh:name "quantityObject" ;
+            sh:description "quantity object with properties for quantity informations" ;
             sh:order 5 ;
             sh:path surface-model:Quantity ],
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node georeference:GeoreferenceShape ;
+            sh:name "georeferenceObject" ;
+            sh:description "georeference object with properties for georeference informations" ;
             sh:order 6 ;
             sh:path surface-model:Georeference ] ;
     sh:targetClass surface-model:SurfaceModel .


### PR DESCRIPTION
# Description

add name and description to groups for all shacls

## Type of change

Please delete options that are not relevant.

- [ ] New type (non-breaking change which adds a type)
- [x] Change (non-breaking change or fix on an existing type)
- [ ] Breaking change (Change that would cause existing Self Descriptions not to be accepted anymore by a Federated Catalogue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any
relevant details for your test configuration

- Test A
- Test B

## Checklist

- [x] My code follows the modelling guidelines of this project
- [x] I have performed a self-review of my own changes
