### PR TITLE
95 instances are sometimes wrong

### DIFF
--- a/environment-model/environment-model_instance.json
+++ b/environment-model/environment-model_instance.json
@@ -57,24 +57,24 @@
       "general:type": "Image"
     }
     },
-	"general:bundleData": {
-		"@type": "general:BundleData",
-		"general:requiredData": {
-		  "@type": "general:Link",
-		  "general:url": {
-			"@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/ODR-3DM/data/MarktplatzGrafing_offset.xodr",
-			"@type": "xsd:anyURI"
-		  },
-		  "general:type": "Asset"
-		},
-		"general:relatedData": {
-		  "@type": "general:Link",
-		  "general:url": {
-			"@value": "https://github.com/scenario.xosc",
-			"@type": "xsd:anyURI"
-		  },
-		  "general:type": "Asset"
-		}
+    "general:bundleData": {
+        "@type": "general:BundleData",
+        "general:requiredData": {
+          "@type": "general:Link",
+          "general:url": {
+            "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/ODR-3DM/data/MarktplatzGrafing_offset.xodr",
+            "@type": "xsd:anyURI"
+          },
+          "general:type": "Asset"
+        },
+        "general:relatedData": {
+          "@type": "general:Link",
+          "general:url": {
+            "@value": "https://github.com/scenario.xosc",
+            "@type": "xsd:anyURI"
+          },
+          "general:type": "Asset"
+        }
     }
   },
   "environment-model:quantity": {
@@ -103,7 +103,7 @@
   "environment-model:content": {
     "@type": "environment-model:Content",
     "environment-model:elements": "profile roads, extrude buildings, powerlines",
-	"environment-model:useCase": "driving",
+    "environment-model:useCase": "driving",
     "environment-model:textureResolution": {
       "@value": "0.1",
       "@type": "xsd:float"

--- a/environment-model/environment-model_instance.json
+++ b/environment-model/environment-model_instance.json
@@ -136,7 +136,7 @@
     }
   },
   "environment-model:georeference": {
-    "@type": "georeference:GeoreferenceShape",
+    "@type": "georeference:Georeference",
     "georeference:projectLocation": {
       "@type": "georeference:ProjectLocation",
       "georeference:country": {

--- a/environment-model/environment-model_instance.json
+++ b/environment-model/environment-model_instance.json
@@ -103,11 +103,7 @@
   "environment-model:content": {
     "@type": "environment-model:Content",
     "environment-model:elements": "profile roads, extrude buildings, powerlines",
-    "environment-model:useCase": "driving",
-    "environment-model:textureResolution": {
-      "@value": "0.1",
-      "@type": "xsd:float"
-    }
+    "environment-model:useCase": "driving"
   },
   "environment-model:project": {
     "@type": "environment-model:Project",

--- a/environment-model/environment-model_shacl.ttl
+++ b/environment-model/environment-model_shacl.ttl
@@ -4,9 +4,11 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 environment-model:EnvironmentModelShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
@@ -53,6 +55,7 @@ environment-model:EnvironmentModelShape a sh:NodeShape ;
 
 environment-model:FormatShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "Unreal DataSmith, Autodesk FBX, OpenSceneGraph, GLTF" ;
             sh:datatype xsd:string ;
             sh:description "Data type definition"@en ;
@@ -74,6 +77,7 @@ environment-model:FormatShape a sh:NodeShape ;
 
 environment-model:ProjectShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "7.7" ;
             sh:datatype xsd:string ;
             sh:description "Tool for the creation of the data"@en ;
@@ -118,6 +122,7 @@ environment-model:ProjectShape a sh:NodeShape ;
 
 environment-model:QualityShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "PBR" ;
             sh:datatype xsd:string ;
             sh:description "Description of quality features"@en ;
@@ -149,6 +154,7 @@ environment-model:QualityShape a sh:NodeShape ;
 
 environment-model:QuantityShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "12000" ;
             sh:datatype xsd:int ;
             sh:description "Total number of all geoemtries(all triangles with a material assignment), instances are considered only once"@en ;

--- a/environment-model/environment-model_shacl.ttl
+++ b/environment-model/environment-model_shacl.ttl
@@ -6,7 +6,8 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 environment-model:EnvironmentModelShape a sh:NodeShape ;
-    sh:property [ sh:maxCount 1 ;
+    sh:closed false ;
+	sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
             sh:name "general object" ;
@@ -51,7 +52,8 @@ environment-model:EnvironmentModelShape a sh:NodeShape ;
     sh:targetClass environment-model:EnvironmentModel .   
 
 environment-model:FormatShape a sh:NodeShape ;
-    sh:property [ skos:example "Unreal DataSmith, Autodesk FBX, OpenSceneGraph, GLTF" ;
+    sh:closed false ;
+	sh:property [ skos:example "Unreal DataSmith, Autodesk FBX, OpenSceneGraph, GLTF" ;
             sh:datatype xsd:string ;
             sh:description "Data type definition"@en ;
             sh:in ("Autodesk FBX" "GLTF" "OpenSceneGraph" "Unreal DataSmith") ;
@@ -71,7 +73,8 @@ environment-model:FormatShape a sh:NodeShape ;
     sh:targetClass environment-model:Format .
 
 environment-model:ProjectShape a sh:NodeShape ;
-    sh:property [ skos:example "7.7" ;
+    sh:closed false ;
+	sh:property [ skos:example "7.7" ;
             sh:datatype xsd:string ;
             sh:description "Tool for the creation of the data"@en ;
             sh:maxCount 1 ;
@@ -114,7 +117,8 @@ environment-model:ProjectShape a sh:NodeShape ;
     sh:targetClass environment-model:Project .
 
 environment-model:QualityShape a sh:NodeShape ;
-    sh:property [ skos:example "PBR" ;
+    sh:closed false ;
+	sh:property [ skos:example "PBR" ;
             sh:datatype xsd:string ;
             sh:description "Description of quality features"@en ;
             sh:maxCount 1 ;
@@ -144,7 +148,8 @@ environment-model:QualityShape a sh:NodeShape ;
     sh:targetClass environment-model:Quality .
 
 environment-model:QuantityShape a sh:NodeShape ;
-    sh:property [ skos:example "12000" ;
+    sh:closed false ;
+	sh:property [ skos:example "12000" ;
             sh:datatype xsd:int ;
             sh:description "Total number of all geoemtries(all triangles with a material assignment), instances are considered only once"@en ;
             sh:maxCount 1 ;

--- a/environment-model/environment-model_shacl.ttl
+++ b/environment-model/environment-model_shacl.ttl
@@ -83,6 +83,8 @@ environment-model:FormatShape a sh:NodeShape ;
     sh:targetClass environment-model:Format .
 
 environment-model:ContentShape a sh:NodeShape ;
+    sh:closed false ;
+    sh:ignoredProperties ( rdf:type ) ;
     sh:property [ skos:example "profile roads, extrude buildings, forests, trees, river, powerlines" ;
             sh:maxCount 1 ;
             sh:datatype xsd:string ;

--- a/general/general_instance.json
+++ b/general/general_instance.json
@@ -7,9 +7,9 @@
     "sh": "http://www.w3.org/ns/shacl#"
   },
   "@id": "did:web:registry.gaia-x.eu:General:PlFjHxuQoH0v7iaVC0QqdxmtQyqY-LQX6D-p",
-  "@type": "general:GeneralShape",
+  "@type": "general:General",
   "general:description": {
-    "@type": "general:DescriptionShape",
+    "@type": "general:Description",
     "gx:name": {
       "@value": "3D Model in Grafing",
       "@type": "xsd:string"
@@ -20,7 +20,7 @@
     }
   },
   "general:data": {
-    "@type": "general:DataShape",
+    "@type": "general:Data",
     "general:size": {
       "@value": "5.8",
       "@type": "xsd:float"
@@ -35,9 +35,9 @@
     }
   },
   "general:links": {
-    "@type": "general:LinksShape",
+    "@type": "general:Links",
     "general:data": {
-      "@type": "general:LinkShape",
+      "@type": "general:Link",
       "general:url": {
         "@value": "https://example.com/video.mpg",
         "@type": "xsd:anyURI"
@@ -46,7 +46,7 @@
     },
     "general:media": [
 		{
-		  "@type": "general:LinkShape",
+		  "@type": "general:Link",
 		  "general:url": {
 			"@value": "https://example.com/model.png",
 			"@type": "xsd:anyURI"
@@ -56,10 +56,10 @@
 	]
   },
   "general:bundleData": {
-    "@type": "general:BundleDataShape",
+    "@type": "general:BundleData",
     "general:requiredData": [
 		{
-		  "@type": "general:LinkShape",
+		  "@type": "general:Link",
 		  "general:url": {
 			"@value": "https://example.com/requiredData",
 			"@type": "xsd:anyURI"
@@ -69,7 +69,7 @@
 	],
     "general:relatedData": [
 		{
-		  "@type": "general:LinkShape",
+		  "@type": "general:Link",
 		  "general:url": {
 			"@value": "https://example.com/relatedData.mpg",
 			"@type": "xsd:anyURI"

--- a/general/general_instance.json
+++ b/general/general_instance.json
@@ -44,56 +44,38 @@
       },
       "general:type": "Video"
     },
-    "general:media": {
-      "@type": "general:Link",
-      "general:url": {
-        "@value": "https://example.com/model.png",
-        "@type": "xsd:anyURI"
-      },
-      "general:type": "Model"
-    }
+    "general:media": [
+		{
+		  "@type": "general:Link",
+		  "general:url": {
+			"@value": "https://example.com/model.png",
+			"@type": "xsd:anyURI"
+		  },
+		  "general:type": "Image"
+		}
+	]
   },
   "general:bundleData": {
     "@type": "general:BundleData",
-    "general:requiredData": {
-      "@type": "general:Link",
-      "general:url": {
-        "@value": "https://example.com/requiredData",
-        "@type": "xsd:anyURI"
-      },
-      "general:type": "3DPreview"
-    },
-    "general:relatedData": {
-      "@type": "general:Link",
-      "general:url": {
-        "@value": "https://example.com/relatedData.mpg",
-        "@type": "xsd:anyURI"
-      },
-      "general:type": "Video"
-    }
-  },
-  "general:media": {
-    "@type": "general:Link",
-    "general:url": {
-      "@value": "https://example.com/model.png",
-      "@type": "xsd:anyURI"
-    },
-    "general:type": "Model"
-  },
-  "general:requiredData": {
-    "@type": "general:Link",
-    "general:url": {
-      "@value": "https://example.com/requiredData",
-      "@type": "xsd:anyURI"
-    },
-    "general:type": "3DPreview"
-  },
-  "general:relatedData": {
-    "@type": "general:Link",
-    "general:url": {
-      "@value": "https://example.com/relatedData.mpg",
-      "@type": "xsd:anyURI"
-    },
-    "general:type": "Video"
+    "general:requiredData": [
+		{
+		  "@type": "general:Link",
+		  "general:url": {
+			"@value": "https://example.com/requiredData",
+			"@type": "xsd:anyURI"
+		  },
+		  "general:type": "3DPreview"
+		}
+	],
+    "general:relatedData": [
+		{
+		  "@type": "general:Link",
+		  "general:url": {
+			"@value": "https://example.com/relatedData.mpg",
+			"@type": "xsd:anyURI"
+		  },
+		  "general:type": "Video"
+		}
+	]
   }
 }

--- a/general/general_instance.json
+++ b/general/general_instance.json
@@ -7,9 +7,9 @@
     "sh": "http://www.w3.org/ns/shacl#"
   },
   "@id": "did:web:registry.gaia-x.eu:General:PlFjHxuQoH0v7iaVC0QqdxmtQyqY-LQX6D-p",
-  "@type": "general:General",
+  "@type": "general:GeneralShape",
   "general:description": {
-    "@type": "general:Description",
+    "@type": "general:DescriptionShape",
     "gx:name": {
       "@value": "3D Model in Grafing",
       "@type": "xsd:string"
@@ -20,7 +20,7 @@
     }
   },
   "general:data": {
-    "@type": "general:Data",
+    "@type": "general:DataShape",
     "general:size": {
       "@value": "5.8",
       "@type": "xsd:float"
@@ -35,9 +35,9 @@
     }
   },
   "general:links": {
-    "@type": "general:Links",
+    "@type": "general:LinksShape",
     "general:data": {
-      "@type": "general:Link",
+      "@type": "general:LinkShape",
       "general:url": {
         "@value": "https://example.com/video.mpg",
         "@type": "xsd:anyURI"
@@ -46,7 +46,7 @@
     },
     "general:media": [
 		{
-		  "@type": "general:Link",
+		  "@type": "general:LinkShape",
 		  "general:url": {
 			"@value": "https://example.com/model.png",
 			"@type": "xsd:anyURI"
@@ -56,10 +56,10 @@
 	]
   },
   "general:bundleData": {
-    "@type": "general:BundleData",
+    "@type": "general:BundleDataShape",
     "general:requiredData": [
 		{
-		  "@type": "general:Link",
+		  "@type": "general:LinkShape",
 		  "general:url": {
 			"@value": "https://example.com/requiredData",
 			"@type": "xsd:anyURI"
@@ -69,7 +69,7 @@
 	],
     "general:relatedData": [
 		{
-		  "@type": "general:Link",
+		  "@type": "general:LinkShape",
 		  "general:url": {
 			"@value": "https://example.com/relatedData.mpg",
 			"@type": "xsd:anyURI"

--- a/general/general_instance.json
+++ b/general/general_instance.json
@@ -45,37 +45,37 @@
       "general:type": "Video"
     },
     "general:media": [
-		{
-		  "@type": "general:Link",
-		  "general:url": {
-			"@value": "https://example.com/model.png",
-			"@type": "xsd:anyURI"
-		  },
-		  "general:type": "Image"
-		}
-	]
+        {
+          "@type": "general:Link",
+          "general:url": {
+            "@value": "https://example.com/model.png",
+            "@type": "xsd:anyURI"
+          },
+          "general:type": "Image"
+        }
+    ]
   },
   "general:bundleData": {
     "@type": "general:BundleData",
     "general:requiredData": [
-		{
-		  "@type": "general:Link",
-		  "general:url": {
-			"@value": "https://example.com/requiredData",
-			"@type": "xsd:anyURI"
-		  },
-		  "general:type": "3DPreview"
-		}
-	],
+        {
+          "@type": "general:Link",
+          "general:url": {
+            "@value": "https://example.com/requiredData",
+            "@type": "xsd:anyURI"
+          },
+          "general:type": "3DPreview"
+        }
+    ],
     "general:relatedData": [
-		{
-		  "@type": "general:Link",
-		  "general:url": {
-			"@value": "https://example.com/relatedData.mpg",
-			"@type": "xsd:anyURI"
-		  },
-		  "general:type": "Video"
-		}
-	]
+        {
+          "@type": "general:Link",
+          "general:url": {
+            "@value": "https://example.com/relatedData.mpg",
+            "@type": "xsd:anyURI"
+          },
+          "general:type": "Video"
+        }
+    ]
   }
 }

--- a/general/general_shacl.ttl
+++ b/general/general_shacl.ttl
@@ -6,8 +6,8 @@
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 general:GeneralShape a sh:NodeShape ;
-	sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
+    sh:closed false ;
+    sh:ignoredProperties ( rdf:type ) ;
     sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:DescriptionShape ;
@@ -39,8 +39,8 @@ general:GeneralShape a sh:NodeShape ;
     
 general:DescriptionShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ sh:datatype xsd:string ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
             sh:description "A human readable name of the entity." ;
             skos:example "3D Model in Grafing" ;
             sh:maxCount 1 ;
@@ -60,8 +60,8 @@ general:DescriptionShape a sh:NodeShape ;
     
 general:DataShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ sh:datatype xsd:float ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:float ;
             sh:description "Size of the file to be downloaded in MB." ;
             skos:example "5.8" ;
             sh:maxCount 1 ;
@@ -89,8 +89,8 @@ general:DataShape a sh:NodeShape ;
     
 general:BundleDataShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ sh:node general:LinkShape ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:node general:LinkShape ;
             sh:description "Reference to required assets" ;
             skos:example "for scenario, link to required hd map" ;
             sh:name "requiredData" ;
@@ -106,8 +106,8 @@ general:BundleDataShape a sh:NodeShape ;
 
 general:LinksShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "link to bundle data, screenshot, video, routing, 3d preview" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "link to bundle data, screenshot, video, routing, 3d preview" ;
             sh:description "Reference to media data"@en ;
             sh:message "Validation of media failed!"@en ;
             sh:name "media"@en ;
@@ -127,8 +127,8 @@ general:LinksShape a sh:NodeShape ;
 
 general:LinkShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ sh:datatype xsd:string ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
             sh:in ("Document" "Image" "Model" "Routing" "Video" "3DPreview" "Asset") ;
             sh:message "Validation of type failed!"@en ;
             sh:description "Choose type of link." ;
@@ -149,8 +149,8 @@ general:LinkShape a sh:NodeShape ;
     
 general:Range2DShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ sh:datatype xsd:float ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:float ;
             sh:message "Validation of max failed!"@en ;
             sh:name "max"@en ;
             sh:order 0 ;

--- a/general/general_shacl.ttl
+++ b/general/general_shacl.ttl
@@ -3,9 +3,11 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 general:GeneralShape a sh:NodeShape ;
 	sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
     sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:DescriptionShape ;
@@ -37,6 +39,7 @@ general:GeneralShape a sh:NodeShape ;
     
 general:DescriptionShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:datatype xsd:string ;
             sh:description "A human readable name of the entity." ;
             skos:example "3D Model in Grafing" ;
@@ -57,6 +60,7 @@ general:DescriptionShape a sh:NodeShape ;
     
 general:DataShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:datatype xsd:float ;
             sh:description "Size of the file to be downloaded in MB." ;
             skos:example "5.8" ;
@@ -85,6 +89,7 @@ general:DataShape a sh:NodeShape ;
     
 general:BundleDataShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:node general:LinkShape ;
             sh:description "Reference to required assets" ;
             skos:example "for scenario, link to required hd map" ;
@@ -101,6 +106,7 @@ general:BundleDataShape a sh:NodeShape ;
 
 general:LinksShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "link to bundle data, screenshot, video, routing, 3d preview" ;
             sh:description "Reference to media data"@en ;
             sh:message "Validation of media failed!"@en ;
@@ -121,6 +127,7 @@ general:LinksShape a sh:NodeShape ;
 
 general:LinkShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:datatype xsd:string ;
             sh:in ("Document" "Image" "Model" "Routing" "Video" "3DPreview" "Asset") ;
             sh:message "Validation of type failed!"@en ;
@@ -142,6 +149,7 @@ general:LinkShape a sh:NodeShape ;
     
 general:Range2DShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:datatype xsd:float ;
             sh:message "Validation of max failed!"@en ;
             sh:name "max"@en ;

--- a/general/general_shacl.ttl
+++ b/general/general_shacl.ttl
@@ -5,6 +5,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 general:GeneralShape a sh:NodeShape ;
+	sh:closed false ;
     sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:DescriptionShape ;
@@ -35,7 +36,8 @@ general:GeneralShape a sh:NodeShape ;
     sh:targetClass general:General .
     
 general:DescriptionShape a sh:NodeShape ;
-    sh:property [ sh:datatype xsd:string ;
+    sh:closed false ;
+	sh:property [ sh:datatype xsd:string ;
             sh:description "A human readable name of the entity." ;
             skos:example "3D Model in Grafing" ;
             sh:maxCount 1 ;
@@ -54,7 +56,8 @@ general:DescriptionShape a sh:NodeShape ;
     sh:targetClass general:Description .    
     
 general:DataShape a sh:NodeShape ;
-    sh:property [ sh:datatype xsd:float ;
+    sh:closed false ;
+	sh:property [ sh:datatype xsd:float ;
             sh:description "Size of the file to be downloaded in MB." ;
             skos:example "5.8" ;
             sh:maxCount 1 ;
@@ -81,7 +84,8 @@ general:DataShape a sh:NodeShape ;
     sh:targetClass general:Data .     
     
 general:BundleDataShape a sh:NodeShape ;
-    sh:property [ sh:node general:LinkShape ;
+    sh:closed false ;
+	sh:property [ sh:node general:LinkShape ;
             sh:description "Reference to required assets" ;
             skos:example "for scenario, link to required hd map" ;
             sh:name "requiredData" ;
@@ -96,7 +100,8 @@ general:BundleDataShape a sh:NodeShape ;
     sh:targetClass general:BundleData .    
 
 general:LinksShape a sh:NodeShape ;
-    sh:property [ skos:example "link to bundle data, screenshot, video, routing, 3d preview" ;
+    sh:closed false ;
+	sh:property [ skos:example "link to bundle data, screenshot, video, routing, 3d preview" ;
             sh:description "Reference to media data"@en ;
             sh:message "Validation of media failed!"@en ;
             sh:name "media"@en ;
@@ -115,7 +120,8 @@ general:LinksShape a sh:NodeShape ;
     sh:targetClass general:Links .
 
 general:LinkShape a sh:NodeShape ;
-    sh:property [ sh:datatype xsd:string ;
+    sh:closed false ;
+	sh:property [ sh:datatype xsd:string ;
             sh:in ("Document" "Image" "Model" "Routing" "Video" "3DPreview" "Asset") ;
             sh:message "Validation of type failed!"@en ;
             sh:description "Choose type of link." ;
@@ -135,7 +141,8 @@ general:LinkShape a sh:NodeShape ;
     sh:targetClass general:Link .
     
 general:Range2DShape a sh:NodeShape ;
-    sh:property [ sh:datatype xsd:float ;
+    sh:closed false ;
+	sh:property [ sh:datatype xsd:float ;
             sh:message "Validation of max failed!"@en ;
             sh:name "max"@en ;
             sh:order 0 ;

--- a/georeference/georeference_instance.json
+++ b/georeference/georeference_instance.json
@@ -66,7 +66,7 @@
         "@type": "xsd:float"
       }
     },
-	"georeference:viewPoint": {
+    "georeference:viewPoint": {
       "@type": "georeference:LatLonCoordinate",
       "georeference:lat": {
         "@value": "52.30626250948862",

--- a/georeference/georeference_instance.json
+++ b/georeference/georeference_instance.json
@@ -6,9 +6,9 @@
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
   "@id": "did:web:registry.gaia-x.eu:Georeference:B67seBpGKVpJGdhXrMGJVG0K2m4AxhzKTBoq",
-  "@type": "georeference:Georeference",
+  "@type": "georeference:GeoreferenceShape",
   "georeference:projectLocation": {
-    "@type": "georeference:ProjectLocation",
+    "@type": "georeference:ProjectLocationShape",
     "georeference:country": {
       "@value": "DE",
       "@type": "xsd:string"
@@ -30,7 +30,7 @@
       "@type": "xsd:string"
     },
     "georeference:boundingBox": {
-      "@type": "georeference:BoundingBox",
+      "@type": "georeference:BoundingBoxShape",
       "georeference:xMin": {
         "@value": "0",
         "@type": "xsd:float"
@@ -50,13 +50,13 @@
     }
   },
   "georeference:geodeticReferenceSystem": {
-    "@type": "georeference:GeodeticReferenceSystem",
+    "@type": "georeference:GeodeticReferenceSystemShape",
     "georeference:coordinateSystem": {
       "@value": "32632",
       "@type": "xsd:string"
     },
     "georeference:origin": {
-      "@type": "georeference:Coordinate2D",
+      "@type": "georeference:Coordinate2DShape",
       "georeference:x": {
         "@value": "2.5",
         "@type": "xsd:float"

--- a/georeference/georeference_instance.json
+++ b/georeference/georeference_instance.json
@@ -6,9 +6,9 @@
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
   "@id": "did:web:registry.gaia-x.eu:Georeference:B67seBpGKVpJGdhXrMGJVG0K2m4AxhzKTBoq",
-  "@type": "georeference:GeoreferenceShape",
+  "@type": "georeference:Georeference",
   "georeference:projectLocation": {
-    "@type": "georeference:ProjectLocationShape",
+    "@type": "georeference:ProjectLocation",
     "georeference:country": {
       "@value": "DE",
       "@type": "xsd:string"
@@ -30,7 +30,7 @@
       "@type": "xsd:string"
     },
     "georeference:boundingBox": {
-      "@type": "georeference:BoundingBoxShape",
+      "@type": "georeference:BoundingBox",
       "georeference:xMin": {
         "@value": "0",
         "@type": "xsd:float"
@@ -50,13 +50,13 @@
     }
   },
   "georeference:geodeticReferenceSystem": {
-    "@type": "georeference:GeodeticReferenceSystemShape",
+    "@type": "georeference:GeodeticReferenceSystem",
     "georeference:coordinateSystem": {
       "@value": "32632",
       "@type": "xsd:string"
     },
     "georeference:origin": {
-      "@type": "georeference:Coordinate2DShape",
+      "@type": "georeference:Coordinate2D",
       "georeference:x": {
         "@value": "2.5",
         "@type": "xsd:float"

--- a/georeference/georeference_instance.json
+++ b/georeference/georeference_instance.json
@@ -5,8 +5,8 @@
     "sh": "http://www.w3.org/ns/shacl#",
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
-  "@id": "did:web:registry.gaia-x.eu:GeoreferenceShape:B67seBpGKVpJGdhXrMGJVG0K2m4AxhzKTBoq",
-  "@type": "georeference:GeoreferenceShape",
+  "@id": "did:web:registry.gaia-x.eu:Georeference:B67seBpGKVpJGdhXrMGJVG0K2m4AxhzKTBoq",
+  "@type": "georeference:Georeference",
   "georeference:projectLocation": {
     "@type": "georeference:ProjectLocation",
     "georeference:country": {

--- a/georeference/georeference_shacl.ttl
+++ b/georeference/georeference_shacl.ttl
@@ -6,8 +6,8 @@
 
 georeference:GeoreferenceShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ sh:maxCount 1 ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:node georeference:ProjectLocationShape ;
@@ -27,8 +27,8 @@ georeference:GeoreferenceShape a sh:NodeShape ;
 
 georeference:GeodeticReferenceSystemShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "Lat: 1.234; Lon 45.23" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "Lat: 1.234; Lon 45.23" ;
     sh:or ( [ sh:minCount 1 ; sh:path georeference:codeEPSG ] 
             [ sh:minCount 1 ; sh:path georeference:coordinateSystemName ] ) ;
     sh:property [ skos:example "Lat: 1.234; Lon 45.23" ;
@@ -77,8 +77,8 @@ georeference:GeodeticReferenceSystemShape a sh:NodeShape ;
 
 georeference:BoundingBoxShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ sh:datatype xsd:float ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:float ;
     sh:property [ skos:example "1.0" ;
             sh:datatype xsd:float ;
             sh:description "minimum bounding value in x axis"@en ;
@@ -120,7 +120,7 @@ georeference:BoundingBoxShape a sh:NodeShape ;
 
 georeference:LatLonCoordinateShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
+    sh:ignoredProperties ( rdf:type ) ;
     sh:property [ skos:example "52.540721" ;
             sh:datatype xsd:float ;
             sh:description "latitude value - y axis"@en ;
@@ -143,8 +143,8 @@ georeference:LatLonCoordinateShape a sh:NodeShape ;
     
 georeference:ProjectLocationShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "DE-BY" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "DE-BY" ;
             sh:datatype xsd:string ;
             sh:description "Code of federal state or province as ISO 3166-2"@en ;
             sh:message "Validation of state failed!"@en ;

--- a/georeference/georeference_shacl.ttl
+++ b/georeference/georeference_shacl.ttl
@@ -115,7 +115,6 @@ georeference:BoundingBoxShape a sh:NodeShape ;
             sh:path georeference:yMax ];
     sh:targetClass georeference:BoundingBox .
 
-
 georeference:LatLonCoordinateShape a sh:NodeShape ;
     sh:closed false ;
     sh:ignoredProperties ( rdf:type ) ;

--- a/georeference/georeference_shacl.ttl
+++ b/georeference/georeference_shacl.ttl
@@ -2,9 +2,11 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 georeference:GeoreferenceShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node georeference:ProjectLocationShape ;
@@ -23,6 +25,7 @@ georeference:GeoreferenceShape a sh:NodeShape ;
 
 georeference:GeodeticReferenceSystemShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "Lat: 1.234; Lon 45.23" ;
             sh:description "World coordinates of map origin"@en ;
             sh:message "Validation of origin failed!"@en ;
@@ -54,6 +57,7 @@ georeference:GeodeticReferenceSystemShape a sh:NodeShape ;
 
 georeference:BoundingBoxShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:datatype xsd:float ;
             sh:message "Validation of yMin failed!"@en ;
             sh:name "yMin"@en ;
@@ -82,6 +86,7 @@ georeference:BoundingBoxShape a sh:NodeShape ;
 
 georeference:Coordinate2DShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:datatype xsd:float ;
             sh:message "Validation of x failed!"@en ;
             sh:name "x"@en ;
@@ -98,6 +103,7 @@ georeference:Coordinate2DShape a sh:NodeShape ;
     
 georeference:ProjectLocationShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "DE-BY" ;
             sh:datatype xsd:string ;
             sh:description "Code of federal state or province as ISO 3166-2"@en ;

--- a/georeference/georeference_shacl.ttl
+++ b/georeference/georeference_shacl.ttl
@@ -4,7 +4,8 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 georeference:GeoreferenceShape a sh:NodeShape ;
-    sh:property [ sh:maxCount 1 ;
+    sh:closed false ;
+	sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node georeference:ProjectLocationShape ;
             sh:name "projectLocation object" ;
@@ -21,7 +22,8 @@ georeference:GeoreferenceShape a sh:NodeShape ;
     sh:targetClass georeference:Georeference .
 
 georeference:GeodeticReferenceSystemShape a sh:NodeShape ;
-    sh:property [ skos:example "Lat: 1.234; Lon 45.23" ;
+    sh:closed false ;
+	sh:property [ skos:example "Lat: 1.234; Lon 45.23" ;
             sh:description "World coordinates of map origin"@en ;
             sh:message "Validation of origin failed!"@en ;
             sh:name "origin"@en ;
@@ -51,7 +53,8 @@ georeference:GeodeticReferenceSystemShape a sh:NodeShape ;
     sh:targetClass georeference:GeodeticReferenceSystem .
 
 georeference:BoundingBoxShape a sh:NodeShape ;
-    sh:property [ sh:datatype xsd:float ;
+    sh:closed false ;
+	sh:property [ sh:datatype xsd:float ;
             sh:message "Validation of yMin failed!"@en ;
             sh:name "yMin"@en ;
             sh:maxCount 1 ;
@@ -78,7 +81,8 @@ georeference:BoundingBoxShape a sh:NodeShape ;
     sh:targetClass georeference:BoundingBox .
 
 georeference:Coordinate2DShape a sh:NodeShape ;
-    sh:property [ sh:datatype xsd:float ;
+    sh:closed false ;
+	sh:property [ sh:datatype xsd:float ;
             sh:message "Validation of x failed!"@en ;
             sh:name "x"@en ;
             sh:maxCount 1 ;
@@ -93,7 +97,8 @@ georeference:Coordinate2DShape a sh:NodeShape ;
     sh:targetClass georeference:Coordinate2D .
     
 georeference:ProjectLocationShape a sh:NodeShape ;
-    sh:property [ skos:example "DE-BY" ;
+    sh:closed false ;
+	sh:property [ skos:example "DE-BY" ;
             sh:datatype xsd:string ;
             sh:description "Code of federal state or province as ISO 3166-2"@en ;
             sh:message "Validation of state failed!"@en ;

--- a/georeference/georeference_shacl.ttl
+++ b/georeference/georeference_shacl.ttl
@@ -28,7 +28,6 @@ georeference:GeoreferenceShape a sh:NodeShape ;
 georeference:GeodeticReferenceSystemShape a sh:NodeShape ;
     sh:closed false ;
     sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ skos:example "Lat: 1.234; Lon 45.23" ;
     sh:or ( [ sh:minCount 1 ; sh:path georeference:codeEPSG ] 
             [ sh:minCount 1 ; sh:path georeference:coordinateSystemName ] ) ;
     sh:property [ skos:example "Lat: 1.234; Lon 45.23" ;
@@ -78,7 +77,6 @@ georeference:GeodeticReferenceSystemShape a sh:NodeShape ;
 georeference:BoundingBoxShape a sh:NodeShape ;
     sh:closed false ;
     sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:float ;
     sh:property [ skos:example "1.0" ;
             sh:datatype xsd:float ;
             sh:description "minimum bounding value in x axis"@en ;

--- a/hdmap/hdmap_instance.json
+++ b/hdmap/hdmap_instance.json
@@ -9,11 +9,11 @@
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
   "@id": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
-  "@type": "hdmap:HdMapShape",
+  "@type": "hdmap:HdMap",
   "hdmap:general": {
-    "@type": "general:GeneralShape",
+    "@type": "general:General",
     "general:description": {
-      "@type": "general:DescriptionShape",
+      "@type": "general:Description",
       "gx:name": {
         "@value": "hdmap example",
         "@type": "xsd:string"
@@ -24,7 +24,7 @@
       }
     },
     "general:data": {
-      "@type": "general:DataShape",
+      "@type": "general:Data",
       "general:size": {
         "@value": "5",
         "@type": "xsd:float"
@@ -39,9 +39,9 @@
       }
     },
     "general:links": {
-      "@type": "general:LinksShape",
+      "@type": "general:Links",
       "general:data": {
-        "@type": "general:LinkShape",
+        "@type": "general:Link",
         "general:url": {
           "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/ODR-3DM/data/MarktplatzGrafing_offset.xodr",
           "@type": "xsd:anyURI"
@@ -50,7 +50,7 @@
       },
       "general:media": [
 		  {
-			"@type": "general:LinkShape",
+			"@type": "general:Link",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/hd-map-asset-example/blob/main/asset/TestfeldNiedersachsen_ALKS_ODR_sample/LICENSE",
 			  "@type": "xsd:anyURI"
@@ -58,7 +58,7 @@
 			"general:type": "Document"
 		  },
 		  {
-			"@type": "general:LinkShape",
+			"@type": "general:Link",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/hd-map-asset-example/blob/main/asset/TestfeldNiedersachsen_ALKS_ODR_sample/visualization/TestfeldNiedersachsen_ALKS_ODR_sample_01.png",
 			  "@type": "xsd:anyURI"
@@ -68,10 +68,10 @@
       ]
     },
     "general:bundleData": {
-      "@type": "general:BundleDataShape",
+      "@type": "general:BundleData",
       "general:requiredData": [
 		  {
-			"@type": "general:LinkShape",
+			"@type": "general:Link",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/3DModel-TG/data/Unreal/Readme.md",
 			  "@type": "xsd:anyURI"
@@ -82,7 +82,7 @@
     }
   },
   "hdmap:format": {
-    "@type": "hdmap:FormatShape",
+    "@type": "hdmap:Format",
     "hdmap:formatType": "ASAM OpenDRIVE",
     "hdmap:version": {
       "@value": "1.6",
@@ -90,7 +90,7 @@
     }
   },
   "hdmap:content": {
-    "@type": "hdmap:ContentShape",
+    "@type": "hdmap:Content",
     "hdmap:roadTypes": "Town",
     "hdmap:laneTypes": [
       "driving",
@@ -100,7 +100,7 @@
     "hdmap:trafficDirection": "right-hand"
   },
   "hdmap:quantity": {
-    "@type": "hdmap:QuantityShape",
+    "@type": "hdmap:Quantity",
     "hdmap:length": {
       "@value": "1.46",
       "@type": "xsd:float"
@@ -130,7 +130,7 @@
       "@type": "xsd:unsignedInt"
     },
     "hdmap:speedLimit": {
-      "@type": "general:Range2DShape",
+      "@type": "general:Range2D",
       "general:min": {
         "@value": "10",
         "@type": "xsd:float"
@@ -146,7 +146,7 @@
     }
   },
   "hdmap:quality": {
-    "@type": "hdmap:QualityShape",
+    "@type": "hdmap:Quality",
     "hdmap:precision": {
       "@value": "0.01",
       "@type": "xsd:float"
@@ -169,7 +169,7 @@
     }
   },
   "hdmap:dataSource": {
-    "@type": "hdmap:DataSourceShape",
+    "@type": "hdmap:DataSource",
     "hdmap:usedDataSources": {
       "@value": "scanner",
       "@type": "xsd:string"
@@ -180,9 +180,9 @@
     }
   },
   "hdmap:georeference": {
-    "@type": "georeference:GeoreferenceShape",
+    "@type": "georeference:Georeference",
     "georeference:projectLocation": {
-      "@type": "georeference:ProjectLocationShape",
+      "@type": "georeference:ProjectLocation",
       "georeference:country": {
         "@value": "DE",
         "@type": "xsd:string"
@@ -204,7 +204,7 @@
         "@type": "xsd:string"
       },
       "georeference:boundingBox": {
-        "@type": "georeference:BoundingBoxShape",
+        "@type": "georeference:BoundingBox",
         "georeference:xMin": {
           "@value": "11.95546",
           "@type": "xsd:float"
@@ -224,13 +224,13 @@
       }
     },
     "georeference:geodeticReferenceSystem": {
-      "@type": "georeference:GeodeticReferenceSystemShape",
+      "@type": "georeference:GeodeticReferenceSystem",
       "georeference:coordinateSystem": {
         "@value": "32632",
         "@type": "xsd:string"
       },
       "georeference:origin": {
-        "@type": "georeference:Coordinate2DShape",
+        "@type": "georeference:Coordinate2D",
         "georeference:x": {
           "@value": "11.96533",
           "@type": "xsd:float"

--- a/hdmap/hdmap_instance.json
+++ b/hdmap/hdmap_instance.json
@@ -24,7 +24,7 @@
       }
     },
     "general:data": {
-      "@type": "general:Data",
+        "@type": "general:Data",
       "general:size": {
         "@value": "5",
         "@type": "xsd:float"
@@ -49,36 +49,36 @@
         "general:type": "Asset"
       },
       "general:media": [
-		  {
-			"@type": "general:Link",
-			"general:url": {
-			  "@value": "https://github.com/GAIA-X4PLC-AAD/hd-map-asset-example/blob/main/asset/TestfeldNiedersachsen_ALKS_ODR_sample/LICENSE",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Document"
-		  },
-		  {
-			"@type": "general:Link",
-			"general:url": {
-			  "@value": "https://github.com/GAIA-X4PLC-AAD/hd-map-asset-example/blob/main/asset/TestfeldNiedersachsen_ALKS_ODR_sample/visualization/TestfeldNiedersachsen_ALKS_ODR_sample_01.png",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Image"
-		  }
+          {
+            "@type": "general:Link",
+            "general:url": {
+              "@value": "https://github.com/GAIA-X4PLC-AAD/hd-map-asset-example/blob/main/asset/TestfeldNiedersachsen_ALKS_ODR_sample/LICENSE",
+              "@type": "xsd:anyURI"
+            },
+            "general:type": "Document"
+          },
+          {
+            "@type": "general:Link",
+            "general:url": {
+              "@value": "https://github.com/GAIA-X4PLC-AAD/hd-map-asset-example/blob/main/asset/TestfeldNiedersachsen_ALKS_ODR_sample/visualization/TestfeldNiedersachsen_ALKS_ODR_sample_01.png",
+              "@type": "xsd:anyURI"
+            },
+            "general:type": "Image"
+          }
       ]
     },
     "general:bundleData": {
       "@type": "general:BundleData",
       "general:requiredData": [
-		  {
-			"@type": "general:Link",
-			"general:url": {
-			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/3DModel-TG/data/Unreal/Readme.md",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Document"
-		  }
-	  ]
+          {
+            "@type": "general:Link",
+            "general:url": {
+              "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/3DModel-TG/data/Unreal/Readme.md",
+              "@type": "xsd:anyURI"
+            },
+            "general:type": "Document"
+          }
+      ]
     }
   },
   "hdmap:format": {
@@ -240,7 +240,7 @@
           "@type": "xsd:float"
         }
       },
-	  "georeference:viewPoint": {
+      "georeference:viewPoint": {
         "@type": "georeference:LatLonCoordinate",
         "georeference:lat": {
           "@value": "48.045414",

--- a/hdmap/hdmap_instance.json
+++ b/hdmap/hdmap_instance.json
@@ -9,11 +9,11 @@
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
   "@id": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
-  "@type": "hdmap:HdMap",
+  "@type": "hdmap:HdMapShape",
   "hdmap:general": {
-    "@type": "general:General",
+    "@type": "general:GeneralShape",
     "general:description": {
-      "@type": "general:Description",
+      "@type": "general:DescriptionShape",
       "gx:name": {
         "@value": "hdmap example",
         "@type": "xsd:string"
@@ -24,7 +24,7 @@
       }
     },
     "general:data": {
-      "@type": "general:Data",
+      "@type": "general:DataShape",
       "general:size": {
         "@value": "5",
         "@type": "xsd:float"
@@ -39,9 +39,9 @@
       }
     },
     "general:links": {
-      "@type": "general:Links",
+      "@type": "general:LinksShape",
       "general:data": {
-        "@type": "general:Link",
+        "@type": "general:LinkShape",
         "general:url": {
           "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/ODR-3DM/data/MarktplatzGrafing_offset.xodr",
           "@type": "xsd:anyURI"
@@ -50,7 +50,7 @@
       },
       "general:media": [
 		  {
-			"@type": "general:Link",
+			"@type": "general:LinkShape",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/hd-map-asset-example/blob/main/asset/TestfeldNiedersachsen_ALKS_ODR_sample/LICENSE",
 			  "@type": "xsd:anyURI"
@@ -58,7 +58,7 @@
 			"general:type": "Document"
 		  },
 		  {
-			"@type": "general:Link",
+			"@type": "general:LinkShape",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/hd-map-asset-example/blob/main/asset/TestfeldNiedersachsen_ALKS_ODR_sample/visualization/TestfeldNiedersachsen_ALKS_ODR_sample_01.png",
 			  "@type": "xsd:anyURI"
@@ -68,10 +68,10 @@
       ]
     },
     "general:bundleData": {
-      "@type": "general:BundleData",
+      "@type": "general:BundleDataShape",
       "general:requiredData": [
 		  {
-			"@type": "general:Link",
+			"@type": "general:LinkShape",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/3DModel-TG/data/Unreal/Readme.md",
 			  "@type": "xsd:anyURI"
@@ -82,7 +82,7 @@
     }
   },
   "hdmap:format": {
-    "@type": "hdmap:Format",
+    "@type": "hdmap:FormatShape",
     "hdmap:formatType": "ASAM OpenDRIVE",
     "hdmap:version": {
       "@value": "1.6",
@@ -90,7 +90,7 @@
     }
   },
   "hdmap:content": {
-    "@type": "hdmap:Content",
+    "@type": "hdmap:ContentShape",
     "hdmap:roadTypes": "Town",
     "hdmap:laneTypes": [
       "driving",
@@ -100,7 +100,7 @@
     "hdmap:trafficDirection": "right-hand"
   },
   "hdmap:quantity": {
-    "@type": "hdmap:Quantity",
+    "@type": "hdmap:QuantityShape",
     "hdmap:length": {
       "@value": "1.46",
       "@type": "xsd:float"
@@ -130,7 +130,7 @@
       "@type": "xsd:unsignedInt"
     },
     "hdmap:speedLimit": {
-      "@type": "general:Range2D",
+      "@type": "general:Range2DShape",
       "general:min": {
         "@value": "10",
         "@type": "xsd:float"
@@ -146,7 +146,7 @@
     }
   },
   "hdmap:quality": {
-    "@type": "hdmap:Quality",
+    "@type": "hdmap:QualityShape",
     "hdmap:precision": {
       "@value": "0.01",
       "@type": "xsd:float"
@@ -169,7 +169,7 @@
     }
   },
   "hdmap:dataSource": {
-    "@type": "hdmap:DataSource",
+    "@type": "hdmap:DataSourceShape",
     "hdmap:usedDataSources": {
       "@value": "scanner",
       "@type": "xsd:string"
@@ -180,9 +180,9 @@
     }
   },
   "hdmap:georeference": {
-    "@type": "georeference:Georeference",
+    "@type": "georeference:GeoreferenceShape",
     "georeference:projectLocation": {
-      "@type": "georeference:ProjectLocation",
+      "@type": "georeference:ProjectLocationShape",
       "georeference:country": {
         "@value": "DE",
         "@type": "xsd:string"
@@ -204,7 +204,7 @@
         "@type": "xsd:string"
       },
       "georeference:boundingBox": {
-        "@type": "georeference:BoundingBox",
+        "@type": "georeference:BoundingBoxShape",
         "georeference:xMin": {
           "@value": "11.95546",
           "@type": "xsd:float"
@@ -224,13 +224,13 @@
       }
     },
     "georeference:geodeticReferenceSystem": {
-      "@type": "georeference:GeodeticReferenceSystem",
+      "@type": "georeference:GeodeticReferenceSystemShape",
       "georeference:coordinateSystem": {
         "@value": "32632",
         "@type": "xsd:string"
       },
       "georeference:origin": {
-        "@type": "georeference:Coordinate2D",
+        "@type": "georeference:Coordinate2DShape",
         "georeference:x": {
           "@value": "11.96533",
           "@type": "xsd:float"

--- a/hdmap/hdmap_instance.json
+++ b/hdmap/hdmap_instance.json
@@ -48,52 +48,37 @@
         },
         "general:type": "Asset"
       },
-      "general:media": {
-        "@type": "general:Link",
-        "general:url": {
-          "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/ODR-3DM/LICENSE.md",
-          "@type": "xsd:anyURI"
-        },
-        "general:type": "Document"
-      }
+      "general:media": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "https://github.com/GAIA-X4PLC-AAD/hd-map-asset-example/blob/main/asset/TestfeldNiedersachsen_ALKS_ODR_sample/LICENSE",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Document"
+		  },
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "https://github.com/GAIA-X4PLC-AAD/hd-map-asset-example/blob/main/asset/TestfeldNiedersachsen_ALKS_ODR_sample/visualization/TestfeldNiedersachsen_ALKS_ODR_sample_01.png",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Image"
+		  }
+      ]
     },
     "general:bundleData": {
       "@type": "general:BundleData",
-      "general:requiredData": {
-        "@type": "general:Link",
-        "general:url": {
-          "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/3DModel-TG/data/Unreal/Readme.md",
-          "@type": "xsd:anyURI"
-        },
-        "general:type": "Document"
-      }
-    },
-    "general:media": {
-      "@type": "general:Link",
-      "general:url": {
-        "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/ODR-3DM/LICENSE.md",
-        "@type": "xsd:anyURI"
-      },
-      "general:type": "Document"
-    },
-    "general:requiredData": {
-      "@type": "general:Link",
-      "general:url": {
-        "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/3DModel-TG/data/Unreal/Readme.md",
-        "@type": "xsd:anyURI"
-      },
-      "general:type": "Document"
-    },
-    "hdmap:speedLimit": {
-      "@type": "general:Range2D",
-      "general:min": {
-        "@value": "10",
-        "@type": "xsd:float"
-      },
-      "general:max": {
-        "@value": "50",
-        "@type": "xsd:float"
-      }
+      "general:requiredData": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/002_MarktplatzGrafing/3DModel-TG/data/Unreal/Readme.md",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Document"
+		  }
+	  ]
     }
   },
   "hdmap:format": {
@@ -221,19 +206,19 @@
       "georeference:boundingBox": {
         "@type": "georeference:BoundingBox",
         "georeference:xMin": {
-          "@value": "5",
+          "@value": "11.95546",
           "@type": "xsd:float"
         },
         "georeference:yMin": {
-          "@value": "5",
+          "@value": "48.03990",
           "@type": "xsd:float"
         },
         "georeference:xMax": {
-          "@value": "10",
+          "@value": "11.97518",
           "@type": "xsd:float"
         },
         "georeference:yMax": {
-          "@value": "10",
+          "@value": "48.04697",
           "@type": "xsd:float"
         }
       }
@@ -247,11 +232,11 @@
       "georeference:origin": {
         "@type": "georeference:Coordinate2D",
         "georeference:x": {
-          "@value": "7.5",
+          "@value": "11.96533",
           "@type": "xsd:float"
         },
         "georeference:y": {
-          "@value": "7.5",
+          "@value": "48.04375",
           "@type": "xsd:float"
         }
       },

--- a/hdmap/hdmap_instance.json
+++ b/hdmap/hdmap_instance.json
@@ -180,7 +180,7 @@
     }
   },
   "hdmap:georeference": {
-    "@type": "georeference:GeoreferenceShape",
+    "@type": "georeference:Georeference",
     "georeference:projectLocation": {
       "@type": "georeference:ProjectLocation",
       "georeference:country": {

--- a/hdmap/hdmap_shacl.ttl
+++ b/hdmap/hdmap_shacl.ttl
@@ -8,8 +8,8 @@
 
 hdmap:HdMapShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property 
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property 
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
@@ -63,8 +63,8 @@ hdmap:HdMapShape a sh:NodeShape ;
 
 hdmap:ContentShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "[Motorway, Rural]" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "[Motorway, Rural]" ;
             sh:datatype xsd:string ;
             sh:description "Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3"@en ;
             sh:in ("Bicycle" "LowSpeed" "Motorway" "Pedestrian" "Rural" "Town" "TownArterial" "TownCollector" "TownExpressway" "TownLocal" "TownPlayStreet" "TownPrivate" "Unknown") ;
@@ -101,8 +101,8 @@ hdmap:ContentShape a sh:NodeShape ;
 
 hdmap:DataSourceShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "3DMS system, Trimble xyz, Riegl xyz" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "3DMS system, Trimble xyz, Riegl xyz" ;
             sh:datatype xsd:string ;
             sh:description "Main acquisition device"@en ;
             sh:maxCount 1 ;
@@ -121,8 +121,8 @@ hdmap:DataSourceShape a sh:NodeShape ;
 
 hdmap:FormatShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "1.5" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "1.5" ;
             sh:datatype xsd:string ;
             sh:description "Version of data format"@en ;
             sh:maxCount 1 ;
@@ -143,8 +143,8 @@ hdmap:FormatShape a sh:NodeShape ;
 
 hdmap:QualityShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "0.1" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "0.1" ;
             sh:datatype xsd:float ;
             sh:description "Accuracy of traffic relevant objects, signs and signals"@en ;
             sh:maxCount 1 ;
@@ -193,8 +193,8 @@ hdmap:QualityShape a sh:NodeShape ;
 
 hdmap:QuantityShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "5" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "5" ;
             sh:datatype xsd:unsignedInt ;
             sh:description "Sum of all junctions defined in the map,  see ODR spec section 10"@en ;
             sh:maxCount 1 ;

--- a/hdmap/hdmap_shacl.ttl
+++ b/hdmap/hdmap_shacl.ttl
@@ -6,7 +6,8 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 hdmap:HdMapShape a sh:NodeShape ;
-    sh:property 
+    sh:closed false ;
+	sh:property 
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
@@ -59,7 +60,8 @@ hdmap:HdMapShape a sh:NodeShape ;
     sh:targetClass hdmap:HdMap .
 
 hdmap:ContentShape a sh:NodeShape ;
-    sh:property [ skos:example "[Motorway, Rural]" ;
+    sh:closed false ;
+	sh:property [ skos:example "[Motorway, Rural]" ;
             sh:datatype xsd:string ;
             sh:description "Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3"@en ;
             sh:in ("Bicycle" "LowSpeed" "Motorway" "Pedestrian" "Rural" "Town" "TownArterial" "TownCollector" "TownExpressway" "TownLocal" "TownPlayStreet" "TownPrivate" "Unknown") ;
@@ -95,7 +97,8 @@ hdmap:ContentShape a sh:NodeShape ;
     sh:targetClass hdmap:Content .
 
 hdmap:DataSourceShape a sh:NodeShape ;
-    sh:property [ skos:example "3DMS system, Trimble xyz, Riegl xyz" ;
+    sh:closed false ;
+	sh:property [ skos:example "3DMS system, Trimble xyz, Riegl xyz" ;
             sh:datatype xsd:string ;
             sh:description "Main acquisition device"@en ;
             sh:maxCount 1 ;
@@ -113,7 +116,8 @@ hdmap:DataSourceShape a sh:NodeShape ;
     sh:targetClass hdmap:DataSource .
 
 hdmap:FormatShape a sh:NodeShape ;
-    sh:property [ skos:example "1.5" ;
+    sh:closed false ;
+	sh:property [ skos:example "1.5" ;
             sh:datatype xsd:string ;
             sh:description "Version of data format"@en ;
             sh:maxCount 1 ;
@@ -133,7 +137,8 @@ hdmap:FormatShape a sh:NodeShape ;
     sh:targetClass hdmap:Format .
 
 hdmap:QualityShape a sh:NodeShape ;
-    sh:property [ skos:example "0.1" ;
+    sh:closed false ;
+	sh:property [ skos:example "0.1" ;
             sh:datatype xsd:float ;
             sh:description "Accuracy of traffic relevant objects, signs and signals"@en ;
             sh:maxCount 1 ;
@@ -181,7 +186,8 @@ hdmap:QualityShape a sh:NodeShape ;
     sh:targetClass hdmap:Quality .
 
 hdmap:QuantityShape a sh:NodeShape ;
-    sh:property [ skos:example "5" ;
+    sh:closed false ;
+	sh:property [ skos:example "5" ;
             sh:datatype xsd:unsignedInt ;
             sh:description "Sum of all junctions defined in the map,  see ODR spec section 10"@en ;
             sh:maxCount 1 ;

--- a/hdmap/hdmap_shacl.ttl
+++ b/hdmap/hdmap_shacl.ttl
@@ -4,9 +4,11 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 hdmap:HdMapShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property 
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
@@ -61,6 +63,7 @@ hdmap:HdMapShape a sh:NodeShape ;
 
 hdmap:ContentShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "[Motorway, Rural]" ;
             sh:datatype xsd:string ;
             sh:description "Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3"@en ;
@@ -98,6 +101,7 @@ hdmap:ContentShape a sh:NodeShape ;
 
 hdmap:DataSourceShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "3DMS system, Trimble xyz, Riegl xyz" ;
             sh:datatype xsd:string ;
             sh:description "Main acquisition device"@en ;
@@ -117,6 +121,7 @@ hdmap:DataSourceShape a sh:NodeShape ;
 
 hdmap:FormatShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "1.5" ;
             sh:datatype xsd:string ;
             sh:description "Version of data format"@en ;
@@ -138,6 +143,7 @@ hdmap:FormatShape a sh:NodeShape ;
 
 hdmap:QualityShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "0.1" ;
             sh:datatype xsd:float ;
             sh:description "Accuracy of traffic relevant objects, signs and signals"@en ;
@@ -187,6 +193,7 @@ hdmap:QualityShape a sh:NodeShape ;
 
 hdmap:QuantityShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "5" ;
             sh:datatype xsd:unsignedInt ;
             sh:description "Sum of all junctions defined in the map,  see ODR spec section 10"@en ;

--- a/ositrace/ositrace_instance.json
+++ b/ositrace/ositrace_instance.json
@@ -9,11 +9,11 @@
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
   "@id": "did:web:registry.gaia-x.eu:OSITrace:T9rkdS19poUrbbAEk3rXMqZ3hzVezwDrrxaf",
-  "@type": "ositrace:OSITraceShape",
+  "@type": "ositrace:OSITrace",
   "ositrace:general": {
-    "@type": "general:GeneralShape",
+    "@type": "general:General",
     "general:description": {
-      "@type": "general:DescriptionShape",
+      "@type": "general:Description",
       "gx:name": {
         "@value": "Cut-out scenario on testing ground",
         "@type": "xsd:string"
@@ -24,7 +24,7 @@
       }
     },
     "general:data": {
-      "@type": "general:DataShape",
+      "@type": "general:Data",
       "general:size": {
         "@value": "126.6",
         "@type": "xsd:float"
@@ -39,9 +39,9 @@
       }
     },
     "general:links": {
-      "@type": "general:LinksShape",
+      "@type": "general:Links",
       "general:data": {
-        "@type": "general:LinkShape",
+        "@type": "general:Link",
         "general:url": {
           "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/20240603T143710.835792Z_sd_360_3200_1448_pmsf_ars548_054814_119_cutout.osi",
           "@type": "xsd:anyURI"
@@ -50,7 +50,7 @@
       },
       "general:media": [
 		  {
-			"@type": "general:LinkShape",
+			"@type": "general:Link",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/20240603T143715.300000Z_position_pmsf_zedf9p_119_cutout.gpx",
 			  "@type": "xsd:anyURI"
@@ -60,10 +60,10 @@
 	  ]
     },
     "general:bundleData": {
-      "@type": "general:BundleDataShape",
+      "@type": "general:BundleData",
       "general:requiredData": [
 		  {
-			"@type": "general:LinkShape",
+			"@type": "general:Link",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/LICENSE.md",
 			  "@type": "xsd:anyURI"
@@ -74,7 +74,7 @@
     }
   },
   "ositrace:format": {
-    "@type": "ositrace:FormatShape",
+    "@type": "ositrace:Format",
     "ositrace:formatType": "ASAM OSI SensorData",
     "ositrace:version": {
       "@value": "3.6.0/3.20.0",
@@ -82,7 +82,7 @@
     }
   },
   "ositrace:content": {
-    "@type": "ositrace:ContentShape",
+    "@type": "ositrace:Content",
     "ositrace:roadTypes": "Rural",
     "ositrace:laneTypes": "driving",
     "ositrace:levelOfDetail": "car",
@@ -100,7 +100,7 @@
       "@type": "xsd:dateTimeStamp"
     },
     "ositrace:hostMovingObject": {
-      "@type": "ositrace:MovingObjectShape",
+      "@type": "ositrace:MovingObject",
       "ositrace:identifier": {
         "@value": "1",
         "@type": "xsd:unsignedLong"
@@ -111,7 +111,7 @@
       }
     },
     "ositrace:targetMovingObject": {
-      "@type": "ositrace:MovingObjectShape",
+      "@type": "ositrace:MovingObject",
       "ositrace:identifier": {
         "@value": "2",
         "@type": "xsd:unsignedLong"
@@ -123,17 +123,17 @@
     }  
   },
   "ositrace:quality": {
-    "@type": "ositrace:QualityShape"
+    "@type": "ositrace:Quality"
   },
   "ositrace:quantity": {
-    "@type": "ositrace:QuantityShape",
+    "@type": "ositrace:Quantity",
     "ositrace:numberFrames": {
       "@value": "1448",
       "@type": "xsd:unsignedInt"
     }
   },
   "ositrace:dataSource": {
-    "@type": "ositrace:DataSourceShape",
+    "@type": "ositrace:DataSource",
     "ositrace:usedDataSources": {
       "@value": "Direct Sensor Capture ARS 548 FW05.38.14 on PMSF MB CLS 500",
       "@type": "xsd:string"
@@ -144,9 +144,9 @@
     }
   },
   "ositrace:georeference": {
-    "@type": "georeference:GeoreferenceShape",
+    "@type": "georeference:Georeference",
     "georeference:projectLocation": {
-      "@type": "georeference:ProjectLocationShape",
+      "@type": "georeference:ProjectLocation",
       "georeference:country": {
         "@value": "DE",
         "@type": "xsd:string"
@@ -168,7 +168,7 @@
         "@type": "xsd:string"
       },
       "georeference:boundingBox": {
-        "@type": "georeference:BoundingBoxShape",
+        "@type": "georeference:BoundingBox",
         "georeference:xMin": {
           "@value": "52.40177964666667",
           "@type": "xsd:float"
@@ -188,13 +188,13 @@
       }
     },
     "georeference:geodeticReferenceSystem": {
-      "@type": "georeference:GeodeticReferenceSystemShape",
+      "@type": "georeference:GeodeticReferenceSystem",
       "georeference:coordinateSystem": {
         "@value": "EPSG::4326",
         "@type": "xsd:string"
       },
       "georeference:origin": {
-        "@type": "georeference:Coordinate2DShape",
+        "@type": "georeference:Coordinate2D",
         "georeference:x": {
           "@value": "52.40177964666667",
           "@type": "xsd:float"

--- a/ositrace/ositrace_instance.json
+++ b/ositrace/ositrace_instance.json
@@ -9,11 +9,11 @@
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
   "@id": "did:web:registry.gaia-x.eu:OSITrace:T9rkdS19poUrbbAEk3rXMqZ3hzVezwDrrxaf",
-  "@type": "ositrace:OSITrace",
+  "@type": "ositrace:OSITraceShape",
   "ositrace:general": {
-    "@type": "general:General",
+    "@type": "general:GeneralShape",
     "general:description": {
-      "@type": "general:Description",
+      "@type": "general:DescriptionShape",
       "gx:name": {
         "@value": "Cut-out scenario on testing ground",
         "@type": "xsd:string"
@@ -24,7 +24,7 @@
       }
     },
     "general:data": {
-      "@type": "general:Data",
+      "@type": "general:DataShape",
       "general:size": {
         "@value": "126.6",
         "@type": "xsd:float"
@@ -39,9 +39,9 @@
       }
     },
     "general:links": {
-      "@type": "general:Links",
+      "@type": "general:LinksShape",
       "general:data": {
-        "@type": "general:Link",
+        "@type": "general:LinkShape",
         "general:url": {
           "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/20240603T143710.835792Z_sd_360_3200_1448_pmsf_ars548_054814_119_cutout.osi",
           "@type": "xsd:anyURI"
@@ -50,7 +50,7 @@
       },
       "general:media": [
 		  {
-			"@type": "general:Link",
+			"@type": "general:LinkShape",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/20240603T143715.300000Z_position_pmsf_zedf9p_119_cutout.gpx",
 			  "@type": "xsd:anyURI"
@@ -60,10 +60,10 @@
 	  ]
     },
     "general:bundleData": {
-      "@type": "general:BundleData",
+      "@type": "general:BundleDataShape",
       "general:requiredData": [
 		  {
-			"@type": "general:Link",
+			"@type": "general:LinkShape",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/LICENSE.md",
 			  "@type": "xsd:anyURI"
@@ -74,7 +74,7 @@
     }
   },
   "ositrace:format": {
-    "@type": "ositrace:Format",
+    "@type": "ositrace:FormatShape",
     "ositrace:formatType": "ASAM OSI SensorData",
     "ositrace:version": {
       "@value": "3.6.0/3.20.0",
@@ -82,7 +82,7 @@
     }
   },
   "ositrace:content": {
-    "@type": "ositrace:Content",
+    "@type": "ositrace:ContentShape",
     "ositrace:roadTypes": "Rural",
     "ositrace:laneTypes": "driving",
     "ositrace:levelOfDetail": "car",
@@ -100,7 +100,7 @@
       "@type": "xsd:dateTimeStamp"
     },
     "ositrace:hostMovingObject": {
-      "@type": "ositrace:MovingObject",
+      "@type": "ositrace:MovingObjectShape",
       "ositrace:identifier": {
         "@value": "1",
         "@type": "xsd:unsignedLong"
@@ -111,7 +111,7 @@
       }
     },
     "ositrace:targetMovingObject": {
-      "@type": "ositrace:MovingObject",
+      "@type": "ositrace:MovingObjectShape",
       "ositrace:identifier": {
         "@value": "2",
         "@type": "xsd:unsignedLong"
@@ -123,17 +123,17 @@
     }  
   },
   "ositrace:quality": {
-    "@type": "ositrace:Quality"
+    "@type": "ositrace:QualityShape"
   },
   "ositrace:quantity": {
-    "@type": "ositrace:Quantity",
+    "@type": "ositrace:QuantityShape",
     "ositrace:numberFrames": {
       "@value": "1448",
       "@type": "xsd:unsignedInt"
     }
   },
   "ositrace:dataSource": {
-    "@type": "ositrace:DataSource",
+    "@type": "ositrace:DataSourceShape",
     "ositrace:usedDataSources": {
       "@value": "Direct Sensor Capture ARS 548 FW05.38.14 on PMSF MB CLS 500",
       "@type": "xsd:string"
@@ -144,9 +144,9 @@
     }
   },
   "ositrace:georeference": {
-    "@type": "georeference:Georeference",
+    "@type": "georeference:GeoreferenceShape",
     "georeference:projectLocation": {
-      "@type": "georeference:ProjectLocation",
+      "@type": "georeference:ProjectLocationShape",
       "georeference:country": {
         "@value": "DE",
         "@type": "xsd:string"
@@ -168,7 +168,7 @@
         "@type": "xsd:string"
       },
       "georeference:boundingBox": {
-        "@type": "georeference:BoundingBox",
+        "@type": "georeference:BoundingBoxShape",
         "georeference:xMin": {
           "@value": "52.40177964666667",
           "@type": "xsd:float"
@@ -188,13 +188,13 @@
       }
     },
     "georeference:geodeticReferenceSystem": {
-      "@type": "georeference:GeodeticReferenceSystem",
+      "@type": "georeference:GeodeticReferenceSystemShape",
       "georeference:coordinateSystem": {
         "@value": "EPSG::4326",
         "@type": "xsd:string"
       },
       "georeference:origin": {
-        "@type": "georeference:Coordinate2D",
+        "@type": "georeference:Coordinate2DShape",
         "georeference:x": {
           "@value": "52.40177964666667",
           "@type": "xsd:float"

--- a/ositrace/ositrace_instance.json
+++ b/ositrace/ositrace_instance.json
@@ -49,28 +49,28 @@
         "general:type": "Asset"
       },
       "general:media": [
-		  {
-			"@type": "general:Link",
-			"general:url": {
-			  "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/20240603T143715.300000Z_position_pmsf_zedf9p_119_cutout.gpx",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Routing"
-		  }
-	  ]
+          {
+            "@type": "general:Link",
+            "general:url": {
+              "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/20240603T143715.300000Z_position_pmsf_zedf9p_119_cutout.gpx",
+              "@type": "xsd:anyURI"
+            },
+            "general:type": "Routing"
+          }
+      ]
     },
     "general:bundleData": {
       "@type": "general:BundleData",
       "general:requiredData": [
-		  {
-			"@type": "general:Link",
-			"general:url": {
-			  "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/LICENSE.md",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Document"
-		  }
-	  ]
+          {
+            "@type": "general:Link",
+            "general:url": {
+              "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/LICENSE.md",
+              "@type": "xsd:anyURI"
+            },
+            "general:type": "Document"
+          }
+      ]
     }
   },
   "ositrace:format": {
@@ -204,7 +204,7 @@
           "@type": "xsd:float"
         }
       },
-	  "georeference:viewPoint": {
+      "georeference:viewPoint": {
         "@type": "georeference:LatLonCoordinate",
         "georeference:lat": {
           "@value": "52.40177964666667",

--- a/ositrace/ositrace_instance.json
+++ b/ositrace/ositrace_instance.json
@@ -48,25 +48,29 @@
         },
         "general:type": "Asset"
       },
-      "general:media": {
-        "@type": "general:Link",
-        "general:url": {
-          "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/20240603T143715.300000Z_position_pmsf_zedf9p_119_cutout.gpx",
-          "@type": "xsd:anyURI"
-        },
-        "general:type": "Routing"
-      }
+      "general:media": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/20240603T143715.300000Z_position_pmsf_zedf9p_119_cutout.gpx",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Routing"
+		  }
+	  ]
     },
     "general:bundleData": {
       "@type": "general:BundleData",
-      "general:requiredData": {
-        "@type": "general:Link",
-        "general:url": {
-          "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/LICENSE.md",
-          "@type": "xsd:anyURI"
-        },
-        "general:type": "Document"
-      }
+      "general:requiredData": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "https://github.com/GAIA-X4PLC-AAD/sensordata/blob/main/ars548/sampledata/119_pmsf_adc_cutout/LICENSE.md",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Document"
+		  }
+	  ]
     }
   },
   "ositrace:format": {
@@ -140,7 +144,7 @@
     }
   },
   "ositrace:georeference": {
-    "@type": "georeference:GeoreferenceShape",
+    "@type": "georeference:Georeference",
     "georeference:projectLocation": {
       "@type": "georeference:ProjectLocation",
       "georeference:country": {

--- a/ositrace/ositrace_shacl.ttl
+++ b/ositrace/ositrace_shacl.ttl
@@ -4,9 +4,11 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 ositrace:OSITraceShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property 
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
@@ -61,6 +63,7 @@ ositrace:OSITraceShape a sh:NodeShape ;
 
 ositrace:ContentShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "[motorway, residential]" ;
             sh:datatype xsd:string ;
             sh:description "Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3"@en ;
@@ -148,6 +151,7 @@ ositrace:ContentShape a sh:NodeShape ;
 
 ositrace:DataSourceShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "PMSF DroneTracker; ARS 548 Sensor Output" ;
             sh:datatype xsd:string ;
             sh:description "Main acquisition device"@en ;
@@ -167,6 +171,7 @@ ositrace:DataSourceShape a sh:NodeShape ;
 
 ositrace:FormatShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "3.7.0" ;
             sh:datatype xsd:string ;
             sh:description "Version of data format"@en ;
@@ -188,6 +193,7 @@ ositrace:FormatShape a sh:NodeShape ;
 
 ositrace:QualityShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "0.1" ;
             sh:datatype xsd:float ;
             sh:description "Accuracy of traffic relevant objects, signs and signals"@en ;
@@ -246,6 +252,7 @@ ositrace:QualityShape a sh:NodeShape ;
 
 ositrace:QuantityShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "1000" ;
             sh:datatype xsd:unsignedInt ;
             sh:description "Number of frames/messages in the trace file"@en ;
@@ -258,6 +265,7 @@ ositrace:QuantityShape a sh:NodeShape ;
 
 ositrace:MovingObjectShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "42" ;
             sh:datatype xsd:unsignedLong ;
             sh:description "Moving object identifier in trace file"@en ;
@@ -279,6 +287,7 @@ ositrace:MovingObjectShape a sh:NodeShape ;
 
 ositrace:EventShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "2024-05-11T13:20:03.250320Z" ;
             sh:datatype xsd:dateTimeStamp ;
             sh:description "Exact timestamp of the event in the recorded trace"@en ;

--- a/ositrace/ositrace_shacl.ttl
+++ b/ositrace/ositrace_shacl.ttl
@@ -6,7 +6,8 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ositrace:OSITraceShape a sh:NodeShape ;
-    sh:property 
+    sh:closed false ;
+	sh:property 
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
@@ -59,7 +60,8 @@ ositrace:OSITraceShape a sh:NodeShape ;
     sh:targetClass ositrace:OSITrace .
 
 ositrace:ContentShape a sh:NodeShape ;
-    sh:property [ skos:example "[motorway, residential]" ;
+    sh:closed false ;
+	sh:property [ skos:example "[motorway, residential]" ;
             sh:datatype xsd:string ;
             sh:description "Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3"@en ;
             sh:in ("Bicycle" "LowSpeed" "Motorway" "Pedestrian" "Rural" "Town" "TownArterial" "TownCollector" "TownExpressway" "TownLocal" "TownPlayStreet" "TownPrivate" "Unknown") ;
@@ -145,7 +147,8 @@ ositrace:ContentShape a sh:NodeShape ;
     sh:targetClass ositrace:Content .
 
 ositrace:DataSourceShape a sh:NodeShape ;
-    sh:property [ skos:example "PMSF DroneTracker; ARS 548 Sensor Output" ;
+    sh:closed false ;
+	sh:property [ skos:example "PMSF DroneTracker; ARS 548 Sensor Output" ;
             sh:datatype xsd:string ;
             sh:description "Main acquisition device"@en ;
             sh:maxCount 1 ;
@@ -163,7 +166,8 @@ ositrace:DataSourceShape a sh:NodeShape ;
     sh:targetClass ositrace:DataSource .
 
 ositrace:FormatShape a sh:NodeShape ;
-    sh:property [ skos:example "3.7.0" ;
+    sh:closed false ;
+	sh:property [ skos:example "3.7.0" ;
             sh:datatype xsd:string ;
             sh:description "Version of data format"@en ;
             sh:maxCount 1 ;
@@ -183,7 +187,8 @@ ositrace:FormatShape a sh:NodeShape ;
     sh:targetClass ositrace:Format .
 
 ositrace:QualityShape a sh:NodeShape ;
-    sh:property [ skos:example "0.1" ;
+    sh:closed false ;
+	sh:property [ skos:example "0.1" ;
             sh:datatype xsd:float ;
             sh:description "Accuracy of traffic relevant objects, signs and signals"@en ;
             sh:maxCount 1 ;
@@ -240,7 +245,8 @@ ositrace:QualityShape a sh:NodeShape ;
     sh:targetClass ositrace:Quality .
 
 ositrace:QuantityShape a sh:NodeShape ;
-    sh:property [ skos:example "1000" ;
+    sh:closed false ;
+	sh:property [ skos:example "1000" ;
             sh:datatype xsd:unsignedInt ;
             sh:description "Number of frames/messages in the trace file"@en ;
             sh:maxCount 1 ;
@@ -251,7 +257,8 @@ ositrace:QuantityShape a sh:NodeShape ;
     sh:targetClass ositrace:Quantity .
 
 ositrace:MovingObjectShape a sh:NodeShape ;
-    sh:property [ skos:example "42" ;
+    sh:closed false ;
+	sh:property [ skos:example "42" ;
             sh:datatype xsd:unsignedLong ;
             sh:description "Moving object identifier in trace file"@en ;
             sh:mincount 1 ;
@@ -271,7 +278,8 @@ ositrace:MovingObjectShape a sh:NodeShape ;
     sh:targetClass ositrace:MovingObject .
 
 ositrace:EventShape a sh:NodeShape ;
-    sh:property [ skos:example "2024-05-11T13:20:03.250320Z" ;
+    sh:closed false ;
+	sh:property [ skos:example "2024-05-11T13:20:03.250320Z" ;
             sh:datatype xsd:dateTimeStamp ;
             sh:description "Exact timestamp of the event in the recorded trace"@en ;
             sh:maxCount 1 ;

--- a/ositrace/ositrace_shacl.ttl
+++ b/ositrace/ositrace_shacl.ttl
@@ -8,8 +8,8 @@
 
 ositrace:OSITraceShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property 
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property 
         [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
@@ -42,7 +42,7 @@ ositrace:OSITraceShape a sh:NodeShape ;
             sh:minCount 1 ;
             sh:node ositrace:QuantityShape ;
             sh:name "quantity object" ;
-            sh:description "quantity object with properties for quantity informations" ;	
+            sh:description "quantity object with properties for quantity informations" ;    
             sh:order 5 ;
             sh:path ositrace:quantity ],
         [ sh:maxCount 1 ;
@@ -63,8 +63,8 @@ ositrace:OSITraceShape a sh:NodeShape ;
 
 ositrace:ContentShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "[motorway, residential]" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "[motorway, residential]" ;
             sh:datatype xsd:string ;
             sh:description "Covered/used road types, defined over ODR element t_road_type, see ODR spec section 8.3"@en ;
             sh:in ("Bicycle" "LowSpeed" "Motorway" "Pedestrian" "Rural" "Town" "TownArterial" "TownCollector" "TownExpressway" "TownLocal" "TownPlayStreet" "TownPrivate" "Unknown") ;
@@ -151,8 +151,8 @@ ositrace:ContentShape a sh:NodeShape ;
 
 ositrace:DataSourceShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "PMSF DroneTracker; ARS 548 Sensor Output" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "PMSF DroneTracker; ARS 548 Sensor Output" ;
             sh:datatype xsd:string ;
             sh:description "Main acquisition device"@en ;
             sh:maxCount 1 ;
@@ -171,8 +171,8 @@ ositrace:DataSourceShape a sh:NodeShape ;
 
 ositrace:FormatShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "3.7.0" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "3.7.0" ;
             sh:datatype xsd:string ;
             sh:description "Version of data format"@en ;
             sh:maxCount 1 ;
@@ -193,8 +193,8 @@ ositrace:FormatShape a sh:NodeShape ;
 
 ositrace:QualityShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "0.1" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "0.1" ;
             sh:datatype xsd:float ;
             sh:description "Accuracy of traffic relevant objects, signs and signals"@en ;
             sh:maxCount 1 ;
@@ -252,8 +252,8 @@ ositrace:QualityShape a sh:NodeShape ;
 
 ositrace:QuantityShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "1000" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "1000" ;
             sh:datatype xsd:unsignedInt ;
             sh:description "Number of frames/messages in the trace file"@en ;
             sh:maxCount 1 ;
@@ -265,8 +265,8 @@ ositrace:QuantityShape a sh:NodeShape ;
 
 ositrace:MovingObjectShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "42" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "42" ;
             sh:datatype xsd:unsignedLong ;
             sh:description "Moving object identifier in trace file"@en ;
             sh:mincount 1 ;
@@ -287,8 +287,8 @@ ositrace:MovingObjectShape a sh:NodeShape ;
 
 ositrace:EventShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "2024-05-11T13:20:03.250320Z" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "2024-05-11T13:20:03.250320Z" ;
             sh:datatype xsd:dateTimeStamp ;
             sh:description "Exact timestamp of the event in the recorded trace"@en ;
             sh:maxCount 1 ;

--- a/scenario/VARIABLES.md
+++ b/scenario/VARIABLES.md
@@ -2,7 +2,6 @@
 
 ## Prefixes
 
-- georeference: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/>
 - scenario: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/scenario/>
 
 ## List of SHACL Properties
@@ -17,7 +16,7 @@
 | ScenarioShape | scenario | traffic | 1 | 1 | traffic object with properties for country specific informations |  | scenario_shacl.ttl |
 | ScenarioShape | scenario | trafficParticipants | 1 | 1 | trafficParticipants object with properties for traffic participants |  | scenario_shacl.ttl |
 | ScenarioShape | scenario | format | 1 | 1 | format object with properties for format informations |  | scenario_shacl.ttl |
-| ScenarioShape | georeference | georeference | 0 | 1 | georeference object with properties for georeference informations |  | scenario_shacl.ttl |
+| ScenarioShape | scenario | georeference | 0 | 1 | georeference object with properties for georeference informations |  | scenario_shacl.ttl |
 | DataSourceShape | scenario | source | 0 | 1 | Capture type | <http://www.w3.org/2001/XMLSchema#string> | scenario_shacl.ttl |
 | EnvironmentalShape | scenario | sunAzimuth | 0 |  | Azimuth of the sun | <http://www.w3.org/2001/XMLSchema#float> | scenario_shacl.ttl |
 | FormatShape | scenario | formatType |  | 1 | Format type definition | <http://www.w3.org/2001/XMLSchema#string> | scenario_shacl.ttl |

--- a/scenario/scenario_instance.json
+++ b/scenario/scenario_instance.json
@@ -156,44 +156,48 @@
     },
     "general:bundleData": {
       "@type": "general:BundleData",
-      "general:requiredData": {
-        "@type": "general:Link",
-        "general:url": {
-          "@value": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
-          "@type": "xsd:anyURI"
-        },
-        "general:type": "Document"
-      }
+      "general:requiredData": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Document"
+		  }
+	  ]
     },
     "general:links": {
       "@type": "general:Links",
       "general:data": {
         "@type": "general:Link",
         "general:url": {
-          "@value": "https://inavlid.link.com/link",
+          "@value": "https://github.com/GAIA-X4PLC-AAD/scenario-asset-example/blob/main/Data/scenario_data/ALKS_Scenario_4.4_1_CutInNoCollision_TEMPLATE.xosc",
           "@type": "xsd:anyURI"
         },
-        "general:type": "Document"
+        "general:type": "Asset"
       },
-      "general:media": {
-        "@type": "general:Link",
-        "general:url": {
-          "@value": "https://inavlid.link.com/media",
-          "@type": "xsd:anyURI"
-        },
-        "general:type": "Document"
-      }
+      "general:media": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "https://inavlid.link.com/media",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Document"
+		  }
+	  ]
     }
   },
   "scenario:source": {
-    "@type": "scenario:DataSourceShape",
+    "@type": "scenario:DataSource",
     "scenario:source": {
       "@value": "Synthetically created",
       "@type": "xsd:string"
     }
   },
-  "georeference:georeference": {
-    "@type": "georeference:GeoreferenceShape",
+  "scenario:georeference": {
+    "@type": "georeference:Georeference",
     "georeference:projectLocation": {
       "@type": "georeference:ProjectLocation",
       "georeference:country": {
@@ -219,19 +223,19 @@
       "georeference:boundingBox": {
         "@type": "georeference:BoundingBox",
         "georeference:xMin": {
-          "@value": "0",
+          "@value": "11.95546",
           "@type": "xsd:float"
         },
         "georeference:yMin": {
-          "@value": "0",
+          "@value": "48.03990",
           "@type": "xsd:float"
         },
         "georeference:xMax": {
-          "@value": "10",
+          "@value": "11.97518",
           "@type": "xsd:float"
         },
         "georeference:yMax": {
-          "@value": "20",
+          "@value": "48.04697",
           "@type": "xsd:float"
         }
       }
@@ -239,17 +243,17 @@
     "georeference:geodeticReferenceSystem": {
       "@type": "georeference:GeodeticReferenceSystem",
       "georeference:coordinateSystem": {
-        "@value": "EPSG:32632",
+        "@value": "32632",
         "@type": "xsd:string"
       },
       "georeference:origin": {
         "@type": "georeference:Coordinate2D",
         "georeference:x": {
-          "@value": "0",
+          "@value": "11.96533",
           "@type": "xsd:float"
         },
         "georeference:y": {
-          "@value": "0",
+          "@value": "48.04375",
           "@type": "xsd:float"
         }
       },
@@ -268,14 +272,6 @@
     "@type": "general:Link",
     "general:url": {
       "@value": "https://inavlid.link.com/my_map.xodr",
-      "@type": "xsd:anyURI"
-    },
-    "general:type": "Document"
-  },
-  "general:media": {
-    "@type": "general:Link",
-    "general:url": {
-      "@value": "https://inavlid.link.com/media",
       "@type": "xsd:anyURI"
     },
     "general:type": "Document"

--- a/scenario/scenario_instance.json
+++ b/scenario/scenario_instance.json
@@ -105,7 +105,7 @@
   "scenario:general": {
     "@type": "general:General",
     "general:description": {
-		"@type": "general:Description",
+        "@type": "general:Description",
       "gx:name": {
         "@value": "Scenario Example",
         "@type": "xsd:string"
@@ -141,28 +141,28 @@
         "general:type": "Asset"
       },
       "general:media": [
-		  {
-			"@type": "general:Link",
-			"general:url": {
-			  "@value": "https://inavlid.link.com/media",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Document"
-		  }
-	  ]
+          {
+            "@type": "general:Link",
+            "general:url": {
+              "@value": "https://inavlid.link.com/media",
+              "@type": "xsd:anyURI"
+            },
+            "general:type": "Document"
+          }
+      ]
     },
     "general:bundleData": {
       "@type": "general:BundleData",
       "general:requiredData": [
-		  {
-			"@type": "general:Link",
-			"general:url": {
-			  "@value": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Document"
-		  }
-	  ]
+          {
+            "@type": "general:Link",
+            "general:url": {
+              "@value": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
+              "@type": "xsd:anyURI"
+            },
+            "general:type": "Document"
+          }
+      ]
     }
   },
   "scenario:source": {
@@ -233,7 +233,7 @@
           "@type": "xsd:float"
         }
       },
-	  "georeference:viewPoint": {
+      "georeference:viewPoint": {
         "@type": "georeference:LatLonCoordinate",
         "georeference:lat": {
           "@value": "52.315173",

--- a/scenario/scenario_instance.json
+++ b/scenario/scenario_instance.json
@@ -9,9 +9,9 @@
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
   "@id": "did:web:registry.gaia-x.eu:Scenario:ERXl1TxE2xQjGodfoKZ9TbPiYnQ-yybNhCu8",
-  "@type": "scenario:scenario",
+  "@type": "scenario:scenarioShape",
   "scenario:common": {
-    "@type": "scenario:Common",
+    "@type": "scenario:CommonShape",
     "scenario:abstractionLevel": "Logical",
     "scenario:timeDate": {
       "@value": "2024-05-27T10:00:00",
@@ -27,7 +27,7 @@
     }
   },
   "scenario:trafficParticipants": {
-    "@type": "scenario:TrafficParticipants",
+    "@type": "scenario:TrafficParticipantsShape",
     "scenario:numberTrafficObjects": {
       "@value": "1",
       "@type": "xsd:unsignedInt"
@@ -54,14 +54,14 @@
     }
   },
   "scenario:environmental": {
-    "@type": "scenario:Environmental",
+    "@type": "scenario:EnvironmentalShape",
     "scenario:sunAzimuth": {
       "@value": "3.1415",
       "@type": "xsd:float"
     }
   },
   "scenario:traffic": {
-    "@type": "scenario:Traffic",
+    "@type": "scenario:TrafficShape",
     "scenario:country": {
       "@value": "Germany",
       "@type": "xsd:string"
@@ -76,9 +76,9 @@
     }
   },
   "scenario:structural": {
-    "@type": "scenario:Structural",
+    "@type": "scenario:StructuralShape",
     "scenario:catalogs": {
-      "@type": "general:Link",
+      "@type": "general:LinkShape",
       "general:url": {
         "@value": "https://inavlid.link.com/my_pedestrian_catalog.xosc",
         "@type": "xsd:anyURI"
@@ -86,7 +86,7 @@
       "general:type": "Document"
     },
     "scenario:trafficSpace": {
-      "@type": "general:Link",
+      "@type": "general:LinkShape",
       "general:url": {
         "@value": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
         "@type": "xsd:anyURI"
@@ -95,7 +95,7 @@
     }
   },
   "scenario:format": {
-    "@type": "scenario:Format",
+    "@type": "scenario:FormatShape",
     "scenario:formatType": "ASAM OpenSCENARIO",
     "scenario:version": {
       "@value": "1.2",
@@ -103,7 +103,7 @@
     }
   },
   "scenario:general": {
-    "@type": "general:General",
+    "@type": "general:GeneralShape",
     "general:DataResource": {
       "@type": "gx:DataResource",
       "gx:expirationDateTime": {
@@ -129,7 +129,7 @@
       "gx:license": "Some License"
     },
     "general:data": {
-      "@type": "general:Data",
+      "@type": "general:DataShape",
       "general:size": {
         "@value": "1.0",
         "@type": "xsd:float"
@@ -144,7 +144,7 @@
       }
     },
     "general:description": {
-      "@type": "general:Description",
+      "@type": "general:DescriptionShape",
       "gx:name": {
         "@value": "Scenario Example",
         "@type": "xsd:string"
@@ -155,10 +155,10 @@
       }
     },
     "general:bundleData": {
-      "@type": "general:BundleData",
+      "@type": "general:BundleDataShape",
       "general:requiredData": [
 		  {
-			"@type": "general:Link",
+			"@type": "general:LinkShape",
 			"general:url": {
 			  "@value": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
 			  "@type": "xsd:anyURI"
@@ -168,9 +168,9 @@
 	  ]
     },
     "general:links": {
-      "@type": "general:Links",
+      "@type": "general:LinksShape",
       "general:data": {
-        "@type": "general:Link",
+        "@type": "general:LinkShape",
         "general:url": {
           "@value": "https://github.com/GAIA-X4PLC-AAD/scenario-asset-example/blob/main/Data/scenario_data/ALKS_Scenario_4.4_1_CutInNoCollision_TEMPLATE.xosc",
           "@type": "xsd:anyURI"
@@ -179,7 +179,7 @@
       },
       "general:media": [
 		  {
-			"@type": "general:Link",
+			"@type": "general:LinkShape",
 			"general:url": {
 			  "@value": "https://inavlid.link.com/media",
 			  "@type": "xsd:anyURI"
@@ -190,16 +190,16 @@
     }
   },
   "scenario:source": {
-    "@type": "scenario:DataSource",
+    "@type": "scenario:DataSourceShape",
     "scenario:source": {
       "@value": "Synthetically created",
       "@type": "xsd:string"
     }
   },
   "scenario:georeference": {
-    "@type": "georeference:Georeference",
+    "@type": "georeference:GeoreferenceShape",
     "georeference:projectLocation": {
-      "@type": "georeference:ProjectLocation",
+      "@type": "georeference:ProjectLocationShape",
       "georeference:country": {
         "@value": "DE",
         "@type": "xsd:string"
@@ -221,7 +221,7 @@
         "@type": "xsd:string"
       },
       "georeference:boundingBox": {
-        "@type": "georeference:BoundingBox",
+        "@type": "georeference:BoundingBoxShape",
         "georeference:xMin": {
           "@value": "11.95546",
           "@type": "xsd:float"
@@ -241,13 +241,13 @@
       }
     },
     "georeference:geodeticReferenceSystem": {
-      "@type": "georeference:GeodeticReferenceSystem",
-      "georeference:coordinateSystem": {
+      "@type": "georeference:GeodeticReferenceSystemShape",
+      "georeference:coordinateSystemShape": {
         "@value": "32632",
         "@type": "xsd:string"
       },
       "georeference:origin": {
-        "@type": "georeference:Coordinate2D",
+        "@type": "georeference:Coordinate2DShape",
         "georeference:x": {
           "@value": "11.96533",
           "@type": "xsd:float"
@@ -261,7 +261,7 @@
     }
   },
   "scenario:catalogs": {
-    "@type": "general:Link",
+    "@type": "general:LinkShape",
     "general:url": {
       "@value": "https://inavlid.link.com/my_pedestrian_catalog.xosc",
       "@type": "xsd:anyURI"
@@ -269,7 +269,7 @@
     "general:type": "Document"
   },
   "scenario:trafficSpace": {
-    "@type": "general:Link",
+    "@type": "general:LinkShape",
     "general:url": {
       "@value": "https://inavlid.link.com/my_map.xodr",
       "@type": "xsd:anyURI"

--- a/scenario/scenario_instance.json
+++ b/scenario/scenario_instance.json
@@ -9,9 +9,9 @@
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
   "@id": "did:web:registry.gaia-x.eu:Scenario:ERXl1TxE2xQjGodfoKZ9TbPiYnQ-yybNhCu8",
-  "@type": "scenario:scenarioShape",
+  "@type": "scenario:scenario",
   "scenario:common": {
-    "@type": "scenario:CommonShape",
+    "@type": "scenario:Common",
     "scenario:abstractionLevel": "Logical",
     "scenario:timeDate": {
       "@value": "2024-05-27T10:00:00",
@@ -27,7 +27,7 @@
     }
   },
   "scenario:trafficParticipants": {
-    "@type": "scenario:TrafficParticipantsShape",
+    "@type": "scenario:TrafficParticipants",
     "scenario:numberTrafficObjects": {
       "@value": "1",
       "@type": "xsd:unsignedInt"
@@ -54,14 +54,14 @@
     }
   },
   "scenario:environmental": {
-    "@type": "scenario:EnvironmentalShape",
+    "@type": "scenario:Environmental",
     "scenario:sunAzimuth": {
       "@value": "3.1415",
       "@type": "xsd:float"
     }
   },
   "scenario:traffic": {
-    "@type": "scenario:TrafficShape",
+    "@type": "scenario:Traffic",
     "scenario:country": {
       "@value": "Germany",
       "@type": "xsd:string"
@@ -76,9 +76,9 @@
     }
   },
   "scenario:structural": {
-    "@type": "scenario:StructuralShape",
+    "@type": "scenario:Structural",
     "scenario:catalogs": {
-      "@type": "general:LinkShape",
+      "@type": "general:Link",
       "general:url": {
         "@value": "https://inavlid.link.com/my_pedestrian_catalog.xosc",
         "@type": "xsd:anyURI"
@@ -86,7 +86,7 @@
       "general:type": "Document"
     },
     "scenario:trafficSpace": {
-      "@type": "general:LinkShape",
+      "@type": "general:Link",
       "general:url": {
         "@value": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
         "@type": "xsd:anyURI"
@@ -95,7 +95,7 @@
     }
   },
   "scenario:format": {
-    "@type": "scenario:FormatShape",
+    "@type": "scenario:Format",
     "scenario:formatType": "ASAM OpenSCENARIO",
     "scenario:version": {
       "@value": "1.2",
@@ -103,8 +103,68 @@
     }
   },
   "scenario:general": {
-    "@type": "general:GeneralShape",
-    "general:DataResource": {
+    "@type": "general:General",
+    "general:description": {
+		"@type": "general:Description",
+      "gx:name": {
+        "@value": "Scenario Example",
+        "@type": "xsd:string"
+      },
+      "gx:description": {
+        "@value": "A sample description of a none existing scenario.",
+        "@type": "xsd:string"
+      }
+    },
+    "general:data": {
+      "@type": "general:Data",
+      "general:size": {
+        "@value": "1.0",
+        "@type": "xsd:float"
+      },
+      "general:contractId": {
+        "@value": "1234567890",
+        "@type": "xsd:string"
+      },
+      "general:recordingTime": {
+        "@value": "2024-06-26T09:00:00",
+        "@type": "xsd:dateTime"
+      }
+    },
+    "general:links": {
+      "@type": "general:Links",
+      "general:data": {
+        "@type": "general:Link",
+        "general:url": {
+          "@value": "https://github.com/GAIA-X4PLC-AAD/scenario-asset-example/blob/main/Data/scenario_data/ALKS_Scenario_4.4_1_CutInNoCollision_TEMPLATE.xosc",
+          "@type": "xsd:anyURI"
+        },
+        "general:type": "Asset"
+      },
+      "general:media": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "https://inavlid.link.com/media",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Document"
+		  }
+	  ]
+    },
+    "general:bundleData": {
+      "@type": "general:BundleData",
+      "general:requiredData": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Document"
+		  }
+	  ]
+    },
+	"general:DataResource": {
       "@type": "gx:DataResource",
       "gx:expirationDateTime": {
         "@value": "2100-01-01T00:00:00",
@@ -127,79 +187,19 @@
       },
       "gx:copyrightOwnedBy": "Sample Entity",
       "gx:license": "Some License"
-    },
-    "general:data": {
-      "@type": "general:DataShape",
-      "general:size": {
-        "@value": "1.0",
-        "@type": "xsd:float"
-      },
-      "general:contractId": {
-        "@value": "1234567890",
-        "@type": "xsd:string"
-      },
-      "general:recordingTime": {
-        "@value": "2024-06-26T09:00:00",
-        "@type": "xsd:dateTime"
-      }
-    },
-    "general:description": {
-      "@type": "general:DescriptionShape",
-      "gx:name": {
-        "@value": "Scenario Example",
-        "@type": "xsd:string"
-      },
-      "gx:description": {
-        "@value": "A sample description of a none existing scenario.",
-        "@type": "xsd:string"
-      }
-    },
-    "general:bundleData": {
-      "@type": "general:BundleDataShape",
-      "general:requiredData": [
-		  {
-			"@type": "general:LinkShape",
-			"general:url": {
-			  "@value": "did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Document"
-		  }
-	  ]
-    },
-    "general:links": {
-      "@type": "general:LinksShape",
-      "general:data": {
-        "@type": "general:LinkShape",
-        "general:url": {
-          "@value": "https://github.com/GAIA-X4PLC-AAD/scenario-asset-example/blob/main/Data/scenario_data/ALKS_Scenario_4.4_1_CutInNoCollision_TEMPLATE.xosc",
-          "@type": "xsd:anyURI"
-        },
-        "general:type": "Asset"
-      },
-      "general:media": [
-		  {
-			"@type": "general:LinkShape",
-			"general:url": {
-			  "@value": "https://inavlid.link.com/media",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Document"
-		  }
-	  ]
     }
   },
   "scenario:source": {
-    "@type": "scenario:DataSourceShape",
+    "@type": "scenario:DataSource",
     "scenario:source": {
       "@value": "Synthetically created",
       "@type": "xsd:string"
     }
   },
   "scenario:georeference": {
-    "@type": "georeference:GeoreferenceShape",
+    "@type": "georeference:Georeference",
     "georeference:projectLocation": {
-      "@type": "georeference:ProjectLocationShape",
+      "@type": "georeference:ProjectLocation",
       "georeference:country": {
         "@value": "DE",
         "@type": "xsd:string"
@@ -221,7 +221,7 @@
         "@type": "xsd:string"
       },
       "georeference:boundingBox": {
-        "@type": "georeference:BoundingBoxShape",
+        "@type": "georeference:BoundingBox",
         "georeference:xMin": {
           "@value": "11.95546",
           "@type": "xsd:float"
@@ -241,13 +241,13 @@
       }
     },
     "georeference:geodeticReferenceSystem": {
-      "@type": "georeference:GeodeticReferenceSystemShape",
-      "georeference:coordinateSystemShape": {
+      "@type": "georeference:GeodeticReferenceSystem",
+      "georeference:coordinateSystem": {
         "@value": "32632",
         "@type": "xsd:string"
       },
       "georeference:origin": {
-        "@type": "georeference:Coordinate2DShape",
+        "@type": "georeference:Coordinate2D",
         "georeference:x": {
           "@value": "11.96533",
           "@type": "xsd:float"
@@ -259,21 +259,5 @@
       },
       "georeference:heightSystem": "Ellipsodial height"
     }
-  },
-  "scenario:catalogs": {
-    "@type": "general:LinkShape",
-    "general:url": {
-      "@value": "https://inavlid.link.com/my_pedestrian_catalog.xosc",
-      "@type": "xsd:anyURI"
-    },
-    "general:type": "Document"
-  },
-  "scenario:trafficSpace": {
-    "@type": "general:LinkShape",
-    "general:url": {
-      "@value": "https://inavlid.link.com/my_map.xodr",
-      "@type": "xsd:anyURI"
-    },
-    "general:type": "Document"
   }
 }

--- a/scenario/scenario_instance.json
+++ b/scenario/scenario_instance.json
@@ -163,30 +163,6 @@
 			"general:type": "Document"
 		  }
 	  ]
-    },
-	"general:DataResource": {
-      "@type": "gx:DataResource",
-      "gx:expirationDateTime": {
-        "@value": "2100-01-01T00:00:00",
-        "@type": "xsd:dateTime"
-      },
-      "gx:containsPII": false,
-      "gx:exposedThrough": {
-        "@id": "https://inavlid.link.com/my_scenario_resource.zip"
-      },
-      "gx:producedBy": {
-        "@id": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base"
-      },
-      "gx:policy": {
-        "@value": "MPL-2.0",
-        "@type": "xsd:string"
-      },
-      "gx:name": {
-        "@value": "Scenario Example",
-        "@type": "xsd:string"
-      },
-      "gx:copyrightOwnedBy": "Sample Entity",
-      "gx:license": "Some License"
     }
   },
   "scenario:source": {

--- a/scenario/scenario_ontology.ttl
+++ b/scenario/scenario_ontology.ttl
@@ -21,3 +21,31 @@ scenario:Scenario a owl:Class ;
     rdfs:comment "Class definition for a scenario"@en ;
     rdfs:subClassOf gx:DataResource ,
                     openlabel:Scenario .
+
+scenario:DataSource a owl:Class ;
+    rdfs:label "class definition for DataSource" ;
+    rdfs:comment "Attributes for DataSource"@en .
+	
+scenario:Environmental a owl:Class ;
+    rdfs:label "class definition for Environmental" ;
+    rdfs:comment "Attributes for Environmental"@en .	
+	
+scenario:Format a owl:Class ;
+    rdfs:label "class definition for Format" ;
+    rdfs:comment "Attributes for Format"@en .		
+	
+scenario:Common a owl:Class ;
+    rdfs:label "class definition for Common" ;
+    rdfs:comment "Attributes for Common"@en .		
+	
+scenario:TrafficParticipants a owl:Class ;
+    rdfs:label "class definition for TrafficParticipants" ;
+    rdfs:comment "Attributes for TrafficParticipants"@en .		
+	
+scenario:Structural a owl:Class ;
+    rdfs:label "class definition for Structural" ;
+    rdfs:comment "Attributes for Structural"@en .	
+	
+scenario:Traffic a owl:Class ;
+    rdfs:label "class definition for Traffic" ;
+    rdfs:comment "Attributes for Traffic"@en .	

--- a/scenario/scenario_ontology.ttl
+++ b/scenario/scenario_ontology.ttl
@@ -25,27 +25,27 @@ scenario:Scenario a owl:Class ;
 scenario:DataSource a owl:Class ;
     rdfs:label "class definition for DataSource" ;
     rdfs:comment "Attributes for DataSource"@en .
-	
+    
 scenario:Environmental a owl:Class ;
     rdfs:label "class definition for Environmental" ;
-    rdfs:comment "Attributes for Environmental"@en .	
-	
+    rdfs:comment "Attributes for Environmental"@en .    
+    
 scenario:Format a owl:Class ;
     rdfs:label "class definition for Format" ;
-    rdfs:comment "Attributes for Format"@en .		
-	
+    rdfs:comment "Attributes for Format"@en .       
+    
 scenario:Common a owl:Class ;
     rdfs:label "class definition for Common" ;
-    rdfs:comment "Attributes for Common"@en .		
-	
+    rdfs:comment "Attributes for Common"@en .       
+    
 scenario:TrafficParticipants a owl:Class ;
     rdfs:label "class definition for TrafficParticipants" ;
-    rdfs:comment "Attributes for TrafficParticipants"@en .		
-	
+    rdfs:comment "Attributes for TrafficParticipants"@en .      
+    
 scenario:Structural a owl:Class ;
     rdfs:label "class definition for Structural" ;
-    rdfs:comment "Attributes for Structural"@en .	
-	
+    rdfs:comment "Attributes for Structural"@en .   
+    
 scenario:Traffic a owl:Class ;
     rdfs:label "class definition for Traffic" ;
-    rdfs:comment "Attributes for Traffic"@en .	
+    rdfs:comment "Attributes for Traffic"@en .  

--- a/scenario/scenario_shacl.ttl
+++ b/scenario/scenario_shacl.ttl
@@ -4,9 +4,11 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 scenario:ScenarioShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
@@ -69,11 +71,12 @@ scenario:ScenarioShape a sh:NodeShape ;
             sh:name "georeference object" ;
             sh:description "georeference object with properties for georeference informations" ;
             sh:order 7 ;
-            sh:path georeference:georeference ] ;
+            sh:path scenario:georeference ] ;
     sh:targetClass scenario:scenario .
  
 scenario:DataSourceShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "captured reality, synthetic" ;
             sh:datatype xsd:string ;
             sh:description "Capture type"@en ;
@@ -87,6 +90,7 @@ scenario:DataSourceShape a sh:NodeShape ;
 
 scenario:EnvironmentalShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "194.01" ;
             sh:datatype xsd:float ;
             sh:description "Azimuth of the sun"@en ;
@@ -99,6 +103,7 @@ scenario:EnvironmentalShape a sh:NodeShape ;
 
 scenario:FormatShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "ASAM OpenSCENARIO" ;
             sh:datatype xsd:string ;
             sh:description "Format type definition"@en ;
@@ -120,6 +125,7 @@ scenario:FormatShape a sh:NodeShape ;
 
 scenario:ScenarioCommonShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "Functional, Logical, Concrete" ;
             sh:datatype xsd:string ;
             sh:description "Pegasus type of scenario"@en ;
@@ -160,6 +166,7 @@ scenario:ScenarioCommonShape a sh:NodeShape ;
 
 scenario:TrafficParticipantsShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "2" ;
             sh:datatype xsd:unsignedInt ;
             sh:description "Count of traffic temporary objects"@en ;
@@ -213,6 +220,7 @@ scenario:TrafficParticipantsShape a sh:NodeShape ;
 
 scenario:StructuralShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "http://mywebsite.de/Catalogs" ;
             sh:description "Link to Catalogs"@en ;
             sh:message "Validation of catalogs failed!"@en ;
@@ -242,6 +250,7 @@ scenario:StructuralShape a sh:NodeShape ;
 
 scenario:TrafficShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "kangaroo crossing" ;
             sh:datatype xsd:string ;
             sh:description "Country specific traffic signs"@en ;

--- a/scenario/scenario_shacl.ttl
+++ b/scenario/scenario_shacl.ttl
@@ -6,7 +6,8 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 scenario:ScenarioShape a sh:NodeShape ;
-    sh:property [ sh:maxCount 1 ;
+    sh:closed false ;
+	sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
             sh:name "general object" ;
@@ -72,7 +73,8 @@ scenario:ScenarioShape a sh:NodeShape ;
     sh:targetClass scenario:scenario .
  
 scenario:DataSourceShape a sh:NodeShape ;
-    sh:property [ skos:example "captured reality, synthetic" ;
+    sh:closed false ;
+	sh:property [ skos:example "captured reality, synthetic" ;
             sh:datatype xsd:string ;
             sh:description "Capture type"@en ;
             sh:maxCount 1 ;
@@ -81,10 +83,11 @@ scenario:DataSourceShape a sh:NodeShape ;
             sh:name "source"@en ;
             sh:order 0 ;
             sh:path scenario:source ] ;
-    sh:targetClass scenario:DataSourceShape .
+    sh:targetClass scenario:DataSource .
 
 scenario:EnvironmentalShape a sh:NodeShape ;
-    sh:property [ skos:example "194.01" ;
+    sh:closed false ;
+	sh:property [ skos:example "194.01" ;
             sh:datatype xsd:float ;
             sh:description "Azimuth of the sun"@en ;
             sh:message "Validation of sunAzimuth failed!"@en ;
@@ -95,7 +98,8 @@ scenario:EnvironmentalShape a sh:NodeShape ;
     sh:targetClass scenario:Environmental .
 
 scenario:FormatShape a sh:NodeShape ;
-    sh:property [ skos:example "ASAM OpenSCENARIO" ;
+    sh:closed false ;
+	sh:property [ skos:example "ASAM OpenSCENARIO" ;
             sh:datatype xsd:string ;
             sh:description "Format type definition"@en ;
             sh:in ("ASAM OpenSCENARIO") ;
@@ -115,7 +119,8 @@ scenario:FormatShape a sh:NodeShape ;
     sh:targetClass scenario:Format .
 
 scenario:ScenarioCommonShape a sh:NodeShape ;
-    sh:property [ skos:example "Functional, Logical, Concrete" ;
+    sh:closed false ;
+	sh:property [ skos:example "Functional, Logical, Concrete" ;
             sh:datatype xsd:string ;
             sh:description "Pegasus type of scenario"@en ;
             sh:in ("Functional" "Logical" "Concrete") ;
@@ -154,7 +159,8 @@ scenario:ScenarioCommonShape a sh:NodeShape ;
     sh:targetClass scenario:Common .
 
 scenario:TrafficParticipantsShape a sh:NodeShape ;
-    sh:property [ skos:example "2" ;
+    sh:closed false ;
+	sh:property [ skos:example "2" ;
             sh:datatype xsd:unsignedInt ;
             sh:description "Count of traffic temporary objects"@en ;
             sh:maxCount 1 ;
@@ -206,7 +212,8 @@ scenario:TrafficParticipantsShape a sh:NodeShape ;
     sh:targetClass scenario:TrafficParticipants .
 
 scenario:StructuralShape a sh:NodeShape ;
-    sh:property [ skos:example "http://mywebsite.de/Catalogs" ;
+    sh:closed false ;
+	sh:property [ skos:example "http://mywebsite.de/Catalogs" ;
             sh:description "Link to Catalogs"@en ;
             sh:message "Validation of catalogs failed!"@en ;
             sh:minCount 0 ;
@@ -234,7 +241,8 @@ scenario:StructuralShape a sh:NodeShape ;
     sh:targetClass scenario:Structural .
 
 scenario:TrafficShape a sh:NodeShape ;
-    sh:property [ skos:example "kangaroo crossing" ;
+    sh:closed false ;
+	sh:property [ skos:example "kangaroo crossing" ;
             sh:datatype xsd:string ;
             sh:description "Country specific traffic signs"@en ;
             sh:maxCount 1 ;

--- a/scenario/scenario_shacl.ttl
+++ b/scenario/scenario_shacl.ttl
@@ -8,8 +8,8 @@
 
 scenario:ScenarioShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ sh:maxCount 1 ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
             sh:name "general object" ;
@@ -76,8 +76,8 @@ scenario:ScenarioShape a sh:NodeShape ;
  
 scenario:DataSourceShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "captured reality, synthetic" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "captured reality, synthetic" ;
             sh:datatype xsd:string ;
             sh:description "Capture type"@en ;
             sh:maxCount 1 ;
@@ -90,8 +90,8 @@ scenario:DataSourceShape a sh:NodeShape ;
 
 scenario:EnvironmentalShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "194.01" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "194.01" ;
             sh:datatype xsd:float ;
             sh:description "Azimuth of the sun"@en ;
             sh:message "Validation of sunAzimuth failed!"@en ;
@@ -103,8 +103,8 @@ scenario:EnvironmentalShape a sh:NodeShape ;
 
 scenario:FormatShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "ASAM OpenSCENARIO" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "ASAM OpenSCENARIO" ;
             sh:datatype xsd:string ;
             sh:description "Format type definition"@en ;
             sh:in ("ASAM OpenSCENARIO") ;
@@ -125,8 +125,8 @@ scenario:FormatShape a sh:NodeShape ;
 
 scenario:ScenarioCommonShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "Functional, Logical, Concrete" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "Functional, Logical, Concrete" ;
             sh:datatype xsd:string ;
             sh:description "Pegasus type of scenario"@en ;
             sh:in ("Functional" "Logical" "Concrete") ;
@@ -135,7 +135,7 @@ scenario:ScenarioCommonShape a sh:NodeShape ;
             sh:name "abstractionLevel"@en ;
             sh:order 0 ;
             sh:path scenario:abstractionLevel ],
-        [ skos:example "2009-06-30T18:30:00+02:00	" ;
+        [ skos:example "2009-06-30T18:30:00+02:00   " ;
             sh:datatype xsd:dateTime ;
             sh:description "Time of the scenario if applicaple. Either time of recording or if synthetic the time it happens."@en ;
             sh:maxCount 1 ;
@@ -166,8 +166,8 @@ scenario:ScenarioCommonShape a sh:NodeShape ;
 
 scenario:TrafficParticipantsShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "2" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "2" ;
             sh:datatype xsd:unsignedInt ;
             sh:description "Count of traffic temporary objects"@en ;
             sh:maxCount 1 ;
@@ -220,8 +220,8 @@ scenario:TrafficParticipantsShape a sh:NodeShape ;
 
 scenario:StructuralShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "http://mywebsite.de/Catalogs" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "http://mywebsite.de/Catalogs" ;
             sh:description "Link to Catalogs"@en ;
             sh:message "Validation of catalogs failed!"@en ;
             sh:minCount 0 ;
@@ -250,8 +250,8 @@ scenario:StructuralShape a sh:NodeShape ;
 
 scenario:TrafficShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "kangaroo crossing" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "kangaroo crossing" ;
             sh:datatype xsd:string ;
             sh:description "Country specific traffic signs"@en ;
             sh:maxCount 1 ;

--- a/scenario/scenario_shacl.ttl
+++ b/scenario/scenario_shacl.ttl
@@ -72,7 +72,7 @@ scenario:ScenarioShape a sh:NodeShape ;
             sh:description "georeference object with properties for georeference informations" ;
             sh:order 7 ;
             sh:path scenario:georeference ] ;
-    sh:targetClass scenario:scenario .
+    sh:targetClass scenario:Scenario .
  
 scenario:DataSourceShape a sh:NodeShape ;
     sh:closed false ;

--- a/surface-model/surface-model_instance.json
+++ b/surface-model/surface-model_instance.json
@@ -9,11 +9,11 @@
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
   "@id": "did:web:registry.gaia-x.eu:SurfaceModel:ERXl1TxE2xQjGodfoKoi1lgYULTW5dCbtfcL",
-  "@type": "surface-model:SurfaceModelShape",
+  "@type": "surface-model:SurfaceModel",
   "surface-model:general": {
-    "@type": "general:GeneralShape",
+    "@type": "general:General",
     "general:description": {
-      "@type": "general:DescriptionShape",
+      "@type": "general:Description",
       "gx:name": {
         "@value": "My surface model",
         "@type": "xsd:string"
@@ -24,7 +24,7 @@
       }
     },
     "general:data": {
-      "@type": "general:DataShape",
+      "@type": "general:Data",
       "general:size": {
         "@value": "50",
         "@type": "xsd:float"
@@ -39,9 +39,9 @@
       }
     },
     "general:links": {
-      "@type": "general:LinksShape",
+      "@type": "general:Links",
       "general:data": {
-        "@type": "general:LinkShape",
+        "@type": "general:Link",
         "general:url": {
           "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/CRG-3DM/data/Achse02f3a967-3850-4614-b884-6a3f3b9034bc_0.1m.crg",
           "@type": "xsd:anyURI"
@@ -50,7 +50,7 @@
       },
       "general:media": [
 		  {
-			"@type": "general:LinkShape",
+			"@type": "general:Link",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/CRG-3DM/LICENSE.md",
 			  "@type": "xsd:anyURI"
@@ -60,10 +60,10 @@
 	  ]
     },
     "general:bundleData": {
-      "@type": "general:BundleDataShape",
+      "@type": "general:BundleData",
       "general:requiredData": [
 		  {
-			"@type": "general:LinkShape",
+			"@type": "general:Link",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/ODR-3DM/data/A39_TestfeldNiedersachsen_CremlingenSurface_offset.xodr",
 			  "@type": "xsd:anyURI"
@@ -73,7 +73,7 @@
 	  ],
       "general:relatedData": [
 		  {
-			"@type": "general:LinkShape",
+			"@type": "general:Link",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/003_A39_TestfeldNiedersachsen_CremlingenLoop/3DModel-TG/data/Unreal/Readme.md",
 			  "@type": "xsd:anyURI"
@@ -84,7 +84,7 @@
     }
   },
   "surface-model:Format": {
-    "@type": "surface-model:FormatShape",
+    "@type": "surface-model:Format",
     "surface-model:formatType": "ASAM OpenCRG",
     "surface-model:version": {
       "@value": "1.1",
@@ -92,11 +92,11 @@
     }
   },
   "surface-model:Data": {
-    "@type": "surface-model:DataShape",
+    "@type": "surface-model:Data",
     "surface-model:dataType": "Height"
   },
   "surface-model:Quality": {
-    "@type": "surface-model:QualityShape",
+    "@type": "surface-model:Quality",
     "surface-model:resolutionLongitudinal": {
       "@value": "0.01",
       "@type": "xsd:float"
@@ -113,7 +113,7 @@
     "surface-model:rampExists": true
   },
   "surface-model:Quantity": {
-    "@type": "surface-model:QuantityShape",
+    "@type": "surface-model:Quantity",
     "surface-model:length": {
       "@value": "1.46",
       "@type": "xsd:float"
@@ -125,9 +125,9 @@
     "surface-model:mapDataField": true
   },
   "surface-model:Georeference": {
-    "@type": "georeference:GeoreferenceShape",
+    "@type": "georeference:Georeference",
     "georeference:projectLocation": {
-      "@type": "georeference:ProjectLocationShape",
+      "@type": "georeference:ProjectLocation",
       "georeference:country": {
         "@value": "DE",
         "@type": "xsd:string"
@@ -149,7 +149,7 @@
         "@type": "xsd:string"
       },
       "georeference:boundingBox": {
-        "@type": "georeference:BoundingBoxShape",
+        "@type": "georeference:BoundingBox",
         "georeference:xMin": {
           "@value": "11.95546",
           "@type": "xsd:float"
@@ -169,13 +169,13 @@
       }
     },
     "georeference:geodeticReferenceSystem": {
-      "@type": "georeference:GeodeticReferenceSystemShape",
+      "@type": "georeference:GeodeticReferenceSystem",
       "georeference:coordinateSystem": {
         "@value": "451989",
         "@type": "xsd:string"
       },
       "georeference:origin": {
-        "@type": "georeference:Coordinate2DShape",
+        "@type": "georeference:Coordinate2D",
         "georeference:x": {
           "@value": "11.96533",
           "@type": "xsd:float"

--- a/surface-model/surface-model_instance.json
+++ b/surface-model/surface-model_instance.json
@@ -125,7 +125,7 @@
     "surface-model:mapDataField": true
   },
   "surface-model:Georeference": {
-    "@type": "georeference:GeoreferenceShape",
+    "@type": "georeference:Georeference",
     "georeference:projectLocation": {
       "@type": "georeference:ProjectLocation",
       "georeference:country": {

--- a/surface-model/surface-model_instance.json
+++ b/surface-model/surface-model_instance.json
@@ -48,33 +48,39 @@
         },
         "general:type": "Asset"
       },
-      "general:media": {
-        "@type": "general:Link",
-        "general:url": {
-          "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/CRG-3DM/LICENSE.md",
-          "@type": "xsd:anyURI"
-        },
-        "general:type": "Document"
-      }
+      "general:media": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/CRG-3DM/LICENSE.md",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Document"
+		  }
+	  ]
     },
     "general:bundleData": {
       "@type": "general:BundleData",
-      "general:requiredData": {
-        "@type": "general:Link",
-        "general:url": {
-          "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/ODR-3DM/data/A39_TestfeldNiedersachsen_CremlingenSurface_offset.xodr",
-          "@type": "xsd:anyURI"
-        },
-        "general:type": "Asset"
-      },
-      "general:relatedData": {
-        "@type": "general:Link",
-        "general:url": {
-          "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/003_A39_TestfeldNiedersachsen_CremlingenLoop/3DModel-TG/data/Unreal/Readme.md",
-          "@type": "xsd:anyURI"
-        },
-        "general:type": "Document"
-      }
+      "general:requiredData": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/ODR-3DM/data/A39_TestfeldNiedersachsen_CremlingenSurface_offset.xodr",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Asset"
+		  }
+	  ],
+      "general:relatedData": [
+		  {
+			"@type": "general:Link",
+			"general:url": {
+			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/003_A39_TestfeldNiedersachsen_CremlingenLoop/3DModel-TG/data/Unreal/Readme.md",
+			  "@type": "xsd:anyURI"
+			},
+			"general:type": "Document"
+		  }
+	  ]
     }
   },
   "surface-model:Format": {
@@ -87,7 +93,7 @@
   },
   "surface-model:Data": {
     "@type": "surface-model:Data",
-    "surface-model:type": "Height"
+    "surface-model:dataType": "Height"
   },
   "surface-model:Quality": {
     "@type": "surface-model:Quality",
@@ -145,19 +151,19 @@
       "georeference:boundingBox": {
         "@type": "georeference:BoundingBox",
         "georeference:xMin": {
-          "@value": "0",
+          "@value": "11.95546",
           "@type": "xsd:float"
         },
         "georeference:yMin": {
-          "@value": "0",
+          "@value": "48.03990",
           "@type": "xsd:float"
         },
         "georeference:xMax": {
-          "@value": "5",
+          "@value": "11.97518",
           "@type": "xsd:float"
         },
         "georeference:yMax": {
-          "@value": "5",
+          "@value": "48.04697",
           "@type": "xsd:float"
         }
       }
@@ -171,39 +177,15 @@
       "georeference:origin": {
         "@type": "georeference:Coordinate2D",
         "georeference:x": {
-          "@value": "2.5",
+          "@value": "11.96533",
           "@type": "xsd:float"
         },
         "georeference:y": {
-          "@value": "2.5",
+          "@value": "48.04375",
           "@type": "xsd:float"
         }
       },
       "georeference:heightSystem": "Ellipsodial height"
     }
-  },
-  "general:media": {
-    "@type": "general:Link",
-    "general:url": {
-      "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/CRG-3DM/LICENSE.md",
-      "@type": "xsd:anyURI"
-    },
-    "general:type": "Document"
-  },
-  "general:requiredData": {
-    "@type": "general:Link",
-    "general:url": {
-      "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/ODR-3DM/data/A39_TestfeldNiedersachsen_CremlingenSurface_offset.xodr",
-      "@type": "xsd:anyURI"
-    },
-    "general:type": "Asset"
-  },
-  "general:relatedData": {
-    "@type": "general:Link",
-    "general:url": {
-      "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/003_A39_TestfeldNiedersachsen_CremlingenLoop/3DModel-TG/data/Unreal/Readme.md",
-      "@type": "xsd:anyURI"
-    },
-    "general:type": "Document"
   }
 }

--- a/surface-model/surface-model_instance.json
+++ b/surface-model/surface-model_instance.json
@@ -9,11 +9,11 @@
     "georeference": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/"
   },
   "@id": "did:web:registry.gaia-x.eu:SurfaceModel:ERXl1TxE2xQjGodfoKoi1lgYULTW5dCbtfcL",
-  "@type": "surface-model:SurfaceModel",
+  "@type": "surface-model:SurfaceModelShape",
   "surface-model:general": {
-    "@type": "general:General",
+    "@type": "general:GeneralShape",
     "general:description": {
-      "@type": "general:Description",
+      "@type": "general:DescriptionShape",
       "gx:name": {
         "@value": "My surface model",
         "@type": "xsd:string"
@@ -24,7 +24,7 @@
       }
     },
     "general:data": {
-      "@type": "general:Data",
+      "@type": "general:DataShape",
       "general:size": {
         "@value": "50",
         "@type": "xsd:float"
@@ -39,9 +39,9 @@
       }
     },
     "general:links": {
-      "@type": "general:Links",
+      "@type": "general:LinksShape",
       "general:data": {
-        "@type": "general:Link",
+        "@type": "general:LinkShape",
         "general:url": {
           "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/CRG-3DM/data/Achse02f3a967-3850-4614-b884-6a3f3b9034bc_0.1m.crg",
           "@type": "xsd:anyURI"
@@ -50,7 +50,7 @@
       },
       "general:media": [
 		  {
-			"@type": "general:Link",
+			"@type": "general:LinkShape",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/CRG-3DM/LICENSE.md",
 			  "@type": "xsd:anyURI"
@@ -60,10 +60,10 @@
 	  ]
     },
     "general:bundleData": {
-      "@type": "general:BundleData",
+      "@type": "general:BundleDataShape",
       "general:requiredData": [
 		  {
-			"@type": "general:Link",
+			"@type": "general:LinkShape",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/ODR-3DM/data/A39_TestfeldNiedersachsen_CremlingenSurface_offset.xodr",
 			  "@type": "xsd:anyURI"
@@ -73,7 +73,7 @@
 	  ],
       "general:relatedData": [
 		  {
-			"@type": "general:Link",
+			"@type": "general:LinkShape",
 			"general:url": {
 			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/003_A39_TestfeldNiedersachsen_CremlingenLoop/3DModel-TG/data/Unreal/Readme.md",
 			  "@type": "xsd:anyURI"
@@ -84,7 +84,7 @@
     }
   },
   "surface-model:Format": {
-    "@type": "surface-model:Format",
+    "@type": "surface-model:FormatShape",
     "surface-model:formatType": "ASAM OpenCRG",
     "surface-model:version": {
       "@value": "1.1",
@@ -92,11 +92,11 @@
     }
   },
   "surface-model:Data": {
-    "@type": "surface-model:Data",
+    "@type": "surface-model:DataShape",
     "surface-model:dataType": "Height"
   },
   "surface-model:Quality": {
-    "@type": "surface-model:Quality",
+    "@type": "surface-model:QualityShape",
     "surface-model:resolutionLongitudinal": {
       "@value": "0.01",
       "@type": "xsd:float"
@@ -113,7 +113,7 @@
     "surface-model:rampExists": true
   },
   "surface-model:Quantity": {
-    "@type": "surface-model:Quantity",
+    "@type": "surface-model:QuantityShape",
     "surface-model:length": {
       "@value": "1.46",
       "@type": "xsd:float"
@@ -125,9 +125,9 @@
     "surface-model:mapDataField": true
   },
   "surface-model:Georeference": {
-    "@type": "georeference:Georeference",
+    "@type": "georeference:GeoreferenceShape",
     "georeference:projectLocation": {
-      "@type": "georeference:ProjectLocation",
+      "@type": "georeference:ProjectLocationShape",
       "georeference:country": {
         "@value": "DE",
         "@type": "xsd:string"
@@ -149,7 +149,7 @@
         "@type": "xsd:string"
       },
       "georeference:boundingBox": {
-        "@type": "georeference:BoundingBox",
+        "@type": "georeference:BoundingBoxShape",
         "georeference:xMin": {
           "@value": "11.95546",
           "@type": "xsd:float"
@@ -169,13 +169,13 @@
       }
     },
     "georeference:geodeticReferenceSystem": {
-      "@type": "georeference:GeodeticReferenceSystem",
+      "@type": "georeference:GeodeticReferenceSystemShape",
       "georeference:coordinateSystem": {
         "@value": "451989",
         "@type": "xsd:string"
       },
       "georeference:origin": {
-        "@type": "georeference:Coordinate2D",
+        "@type": "georeference:Coordinate2DShape",
         "georeference:x": {
           "@value": "11.96533",
           "@type": "xsd:float"

--- a/surface-model/surface-model_instance.json
+++ b/surface-model/surface-model_instance.json
@@ -49,38 +49,38 @@
         "general:type": "Asset"
       },
       "general:media": [
-		  {
-			"@type": "general:Link",
-			"general:url": {
-			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/CRG-3DM/LICENSE.md",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Document"
-		  }
-	  ]
+          {
+            "@type": "general:Link",
+            "general:url": {
+              "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/CRG-3DM/LICENSE.md",
+              "@type": "xsd:anyURI"
+            },
+            "general:type": "Document"
+          }
+      ]
     },
     "general:bundleData": {
       "@type": "general:BundleData",
       "general:requiredData": [
-		  {
-			"@type": "general:Link",
-			"general:url": {
-			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/ODR-3DM/data/A39_TestfeldNiedersachsen_CremlingenSurface_offset.xodr",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Asset"
-		  }
-	  ],
+          {
+            "@type": "general:Link",
+            "general:url": {
+              "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/004_A39_TestfeldNiedersachsen_CremlingenSurface/ODR-3DM/data/A39_TestfeldNiedersachsen_CremlingenSurface_offset.xodr",
+              "@type": "xsd:anyURI"
+            },
+            "general:type": "Asset"
+          }
+      ],
       "general:relatedData": [
-		  {
-			"@type": "general:Link",
-			"general:url": {
-			  "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/003_A39_TestfeldNiedersachsen_CremlingenLoop/3DModel-TG/data/Unreal/Readme.md",
-			  "@type": "xsd:anyURI"
-			},
-			"general:type": "Document"
-		  }
-	  ]
+          {
+            "@type": "general:Link",
+            "general:url": {
+              "@value": "https://github.com/GAIA-X4PLC-AAD/map-and-scenario-data/blob/main/data/003_A39_TestfeldNiedersachsen_CremlingenLoop/3DModel-TG/data/Unreal/Readme.md",
+              "@type": "xsd:anyURI"
+            },
+            "general:type": "Document"
+          }
+      ]
     }
   },
   "surface-model:Format": {
@@ -196,7 +196,7 @@
           "@type": "xsd:float"
         }
       },
-	  "georeference:viewPoint": {
+      "georeference:viewPoint": {
         "@type": "georeference:LatLonCoordinate",
         "georeference:lat": {
           "@value": "48.335628",

--- a/surface-model/surface-model_shacl.ttl
+++ b/surface-model/surface-model_shacl.ttl
@@ -6,7 +6,8 @@
 @prefix georeference: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/> .
 
 surface-model:SurfaceModelShape a sh:NodeShape ;
-    sh:property [ sh:maxCount 1 ;
+    sh:closed false ;
+	sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
             sh:name "general object" ;
@@ -51,7 +52,8 @@ surface-model:SurfaceModelShape a sh:NodeShape ;
     sh:targetClass surface-model:SurfaceModel .
     
 surface-model:DataShape a sh:NodeShape ;
-    sh:property [ skos:example "nan" ;
+    sh:closed false ;
+	sh:property [ skos:example "nan" ;
             sh:datatype xsd:string ;
             sh:description "Height, friction values, grey values"@en ;
             sh:maxCount 1 ;
@@ -62,7 +64,8 @@ surface-model:DataShape a sh:NodeShape ;
     sh:targetClass surface-model:Data .
 
 surface-model:FormatShape a sh:NodeShape ;
-    sh:property [ skos:example "ASAM OpenCRG; DLM" ;
+    sh:closed false ;
+	sh:property [ skos:example "ASAM OpenCRG; DLM" ;
             sh:datatype xsd:string ;
             sh:description "Format type definition"@en ;
             sh:in ("ASAM OpenCRG" "DLM") ;
@@ -82,7 +85,8 @@ surface-model:FormatShape a sh:NodeShape ;
     sh:targetClass surface-model:Format .
 
 surface-model:QualityShape a sh:NodeShape ;
-    sh:property [ skos:example "0.01" ;
+    sh:closed false ;
+	sh:property [ skos:example "0.01" ;
             sh:datatype xsd:float ;
             sh:description "Longitudinal resolution "@en ;
             sh:maxCount 1 ;
@@ -125,7 +129,8 @@ surface-model:QualityShape a sh:NodeShape ;
     sh:targetClass surface-model:Quality .
 
 surface-model:QuantityShape a sh:NodeShape ;
-    sh:property [ skos:example "yes" ;
+    sh:closed false ;
+	sh:property [ skos:example "yes" ;
             sh:datatype xsd:boolean ;
             sh:description "Is projection system provided within the dataset"@en ;
             sh:maxCount 1 ;

--- a/surface-model/surface-model_shacl.ttl
+++ b/surface-model/surface-model_shacl.ttl
@@ -8,8 +8,8 @@
 
 surface-model:SurfaceModelShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ sh:maxCount 1 ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
             sh:name "general object" ;
@@ -55,8 +55,8 @@ surface-model:SurfaceModelShape a sh:NodeShape ;
     
 surface-model:DataShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "nan" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "nan" ;
             sh:datatype xsd:string ;
             sh:description "Height, friction values, grey values"@en ;
             sh:maxCount 1 ;
@@ -68,8 +68,8 @@ surface-model:DataShape a sh:NodeShape ;
 
 surface-model:FormatShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "ASAM OpenCRG; DLM" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "ASAM OpenCRG; DLM" ;
             sh:datatype xsd:string ;
             sh:description "Format type definition"@en ;
             sh:in ("ASAM OpenCRG" "DLM") ;
@@ -90,8 +90,8 @@ surface-model:FormatShape a sh:NodeShape ;
 
 surface-model:QualityShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "0.01" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "0.01" ;
             sh:datatype xsd:float ;
             sh:description "Longitudinal resolution "@en ;
             sh:maxCount 1 ;
@@ -135,8 +135,8 @@ surface-model:QualityShape a sh:NodeShape ;
 
 surface-model:QuantityShape a sh:NodeShape ;
     sh:closed false ;
-	sh:ignoredProperties ( rdf:type ) ;
-	sh:property [ skos:example "yes" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ skos:example "yes" ;
             sh:datatype xsd:boolean ;
             sh:description "Is projection system provided within the dataset"@en ;
             sh:maxCount 1 ;

--- a/surface-model/surface-model_shacl.ttl
+++ b/surface-model/surface-model_shacl.ttl
@@ -4,9 +4,11 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix general: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/general/> .
 @prefix georeference: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/georeference/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 surface-model:SurfaceModelShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:node general:GeneralShape ;
@@ -53,6 +55,7 @@ surface-model:SurfaceModelShape a sh:NodeShape ;
     
 surface-model:DataShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "nan" ;
             sh:datatype xsd:string ;
             sh:description "Height, friction values, grey values"@en ;
@@ -65,6 +68,7 @@ surface-model:DataShape a sh:NodeShape ;
 
 surface-model:FormatShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "ASAM OpenCRG; DLM" ;
             sh:datatype xsd:string ;
             sh:description "Format type definition"@en ;
@@ -86,6 +90,7 @@ surface-model:FormatShape a sh:NodeShape ;
 
 surface-model:QualityShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "0.01" ;
             sh:datatype xsd:float ;
             sh:description "Longitudinal resolution "@en ;
@@ -130,6 +135,7 @@ surface-model:QualityShape a sh:NodeShape ;
 
 surface-model:QuantityShape a sh:NodeShape ;
     sh:closed false ;
+	sh:ignoredProperties ( rdf:type ) ;
 	sh:property [ skos:example "yes" ;
             sh:datatype xsd:boolean ;
             sh:description "Is projection system provided within the dataset"@en ;


### PR DESCRIPTION
# Description

fix instance.json's
- remove shape in name
- media, requiredData, relatedData as lists
- remove duplicate link entries
- valid coordinates for georeference:BoundingBox/origin


## Type of change

Please delete options that are not relevant.

- [ ] New type (non-breaking change which adds a type)
- [x] Change (non-breaking change or fix on an existing type)
- [ ] Breaking change (Change that would cause existing Self Descriptions not to be accepted anymore by a Federated Catalogue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any
relevant details for your test configuration

- https://shacl.org/playground/
- provider-tools\jsonLD_validator

## Checklist

- [x] My code follows the modelling guidelines of this project
- [x] I have performed a self-review of my own changes
