### PR TITLE
add a release management framework

### DIFF
--- a/.github/workflows/create-initial-subfolders-and-releases.yml
+++ b/.github/workflows/create-initial-subfolders-and-releases.yml
@@ -1,0 +1,66 @@
+name: Create Initial Subfolder Versions and Releases
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-initial-subfolders-and-releases:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Fetch all history for all branches and tags
+
+      - name: Get list of domain subfolders
+        id: subfolders
+        run: |
+          find . -mindepth 1 -maxdepth 1 -type d | sed 's|./||' | grep -v '^\.' | grep -v '^src$' > subfolders.txt
+          subfolders=$(cat subfolders.txt | tr '\n' ' ')
+          if [ -z "$subfolders" ]; then
+            echo "No subfolders found"
+            exit 1
+          fi
+          echo "subfolders=$subfolders" >> $GITHUB_ENV
+          echo "Subfolders: $subfolders"
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "create-initial-subfolder-release-job@gaia-x4plcaad.info"
+          git config --global user.name "GitHub-Action"
+
+      - name: Create initial version subfolders
+        run: |
+          python3 src/create_initial_subfolder.py
+
+      - name: Update @prefix lines in TTL files and @context in JSON files
+        run: |
+          python3 src/update_prefixes.py
+
+      - name: Commit changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add .
+          git commit -m "Move files to initial version subfolders and update @prefix lines and @context entries"
+          git push origin main
+
+      - name: Create releases for subfolders
+        run: |
+          subfolders=$(cat subfolders.txt | tr '\n' ' ')
+          for folder in $subfolders; do
+            latest_tag=$(git tag -l "${folder}_v*" | sort -V | tail -n 1)
+            if [ -n "$latest_tag" ]; then
+              echo "latest_tag: $latest_tag"
+              version_folder="v${latest_tag#*_v}"
+              echo "version_folder: $version_folder"
+              version_folder=${version_folder%%-*}
+              echo "version_folder: $version_folder"
+              zip -r "${folder}_${version_folder}.zip" "${folder}/${version_folder}"
+              gh release create "$latest_tag" "${folder}_${version_folder}.zip" --title "$latest_tag" --notes "Release for $folder version $version_folder"
+            fi
+          done

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -1,0 +1,95 @@
+name: Create Releases
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  create-releases:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'create-releases')
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      # Check out the repository
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # Get the base and head commit SHAs
+      - name: Get the base and head commit SHAs
+        id: commits
+        run: |
+          BASE_SHA=$(jq -r .pull_request.base.sha < $GITHUB_EVENT_PATH)
+          HEAD_SHA=$(jq -r .pull_request.head.sha < $GITHUB_EVENT_PATH)
+          echo "BASE_SHA=$BASE_SHA" >> $GITHUB_ENV
+          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
+
+      # Get the list of changed files
+      - name: Get list of changed files
+        id: changes
+        run: |
+          git fetch origin main
+          git diff --name-only $BASE_SHA $HEAD_SHA > changed_files.txt
+          echo "files=$(cat changed_files.txt | tr '\n' ' ')" >> $GITHUB_ENV
+          echo "Changed files: $(cat changed_files.txt)"
+
+      # Get the list of subfolders
+      - name: Get list of subfolders
+        id: subfolders
+        run: |
+          ls -d */ > subfolders.txt
+          subfolders=$(cat subfolders.txt | tr '\n' ' ' | sed 's|/||g')
+          if [ -z "$subfolders" ]; then
+            echo "No subfolders found"
+            exit 1
+          fi
+          echo "subfolders=$subfolders" >> $GITHUB_ENV
+          echo "Subfolders: $subfolders"
+
+      # Configure Git
+      - name: Configure Git
+        run: |
+          git config --global user.email "create-release-job@gaia-x4plcaad.info"
+          git config --global user.name "GitHub-Action"
+
+      # Determine version bump
+      - name: Determine version bump
+        id: version
+        run: |
+          LABELS=$(jq -r '.pull_request.labels[].name' < $GITHUB_EVENT_PATH)
+          if echo "$LABELS" | grep -q "major"; then
+            echo "bump=major" >> $GITHUB_ENV
+          elif echo "$LABELS" | grep -q "minor"; then
+            echo "bump=minor" >> $GITHUB_ENV
+          elif echo "$LABELS" | grep -q "patch"; then
+            echo "bump=patch" >> $GITHUB_ENV
+          else
+            echo "Error: No valid label found. Please add a 'major', 'minor', or 'patch' label to the pull request."
+            exit 1
+          fi
+          echo "Version bump: ${{ env.bump }}"
+
+      # Create version subfolders and update prefixes
+      - name: Create version subfolders and update prefixes
+        env:
+          BUMP_TYPE: ${{ env.bump }}
+        run: |
+          python3 src/create_subfolder.py
+
+      # Release Subfolders
+      - name: Release Subfolders
+        env:
+          BUMP_TYPE: ${{ env.bump }}
+        run: |
+          python3 src/release_folder.py
+
+      # Clean up temporary files
+      - name: Clean up temporary files
+        run: |
+          rm -f versions.txt subfolders.txt changed_files.txt

--- a/.github/workflows/create-version-folder.yml
+++ b/.github/workflows/create-version-folder.yml
@@ -1,0 +1,96 @@
+name: Create Version Folder
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  create-version-folder:
+    if: contains(github.event.pull_request.labels.*.name, 'create-version-folder')
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      # Check out the repository
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # Get the base and head commit SHAs
+      - name: Get the base and head commit SHAs
+        id: commits
+        run: |
+          BASE_SHA=$(jq -r .pull_request.base.sha < $GITHUB_EVENT_PATH)
+          HEAD_SHA=$(jq -r .pull_request.head.sha < $GITHUB_EVENT_PATH)
+          echo "BASE_SHA=$BASE_SHA" >> $GITHUB_ENV
+          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
+
+      # Get the list of changed files between the base and head commits
+      - name: Get list of changed files
+        id: changes
+        run: |
+          git fetch origin main
+          git diff --name-only $BASE_SHA $HEAD_SHA > changed_files.txt
+          echo "files=$(cat changed_files.txt | tr '\n' ' ')" >> $GITHUB_ENV
+          echo "Changed files: $(cat changed_files.txt)"
+
+      # Get the list of subfolders in the repository
+      - name: Get list of subfolders
+        id: subfolders
+        run: |
+          ls -d */ > subfolders.txt
+          subfolders=$(cat subfolders.txt | tr '\n' ' ' | sed 's|/||g')
+          if [ -z "$subfolders" ]; then
+            echo "No subfolders found"
+            exit 1
+          fi
+          echo "subfolders=$subfolders" >> $GITHUB_ENV
+          echo "Subfolders: $subfolders"
+
+      # Configure Git with user details
+      - name: Configure Git
+        run: |
+          git config --global user.email "create-version-folder@gaia-x4plcaad.info"
+          git config --global user.name "GitHub-Action"
+
+      # Determine the version bump based on labels
+      - name: Determine version bump
+        id: version
+        run: |
+          LABELS=$(jq -r '.pull_request.labels[].name' < $GITHUB_EVENT_PATH)
+          if echo "$LABELS" | grep -q "major"; then
+            echo "bump=major" >> $GITHUB_ENV
+          elif echo "$LABELS" | grep -q "minor"; then
+            echo "bump=minor" >> $GITHUB_ENV
+          elif echo "$LABELS" | grep -q "patch"; then
+            echo "bump=patch" >> $GITHUB_ENV
+          else
+            echo "Error: No valid label found. Please add a 'major', 'minor', or 'patch' label to the pull request."
+            exit 1
+          fi
+          echo "Version bump: ${{ env.bump }}"
+
+      # Create version subfolders and update prefixes
+      - name: Create version subfolders and update prefixes
+        env:
+          BUMP_TYPE: ${{ env.bump }}
+        run: |
+          python3 src/create_subfolder.py
+
+      # Commit the changes and push to the current branch
+      - name: Commit changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git add .
+            git commit --signoff -m "Move files to version subfolders and update @prefix lines and @context entries"
+            git pull --rebase origin ${{ env.BRANCH_NAME }}
+            git push origin HEAD:${{ env.BRANCH_NAME }}
+          else
+            echo "No changes to commit"
+          fi

--- a/README.md
+++ b/README.md
@@ -130,6 +130,95 @@ This section describes guidelines that _must_ be followed when applying changes 
                 sh:path <your_prefix>:marketplace-info ],
     ```
 
+## Release Management
+
+Creating a new domain-specific release begins with creating a pull request in the main branch.
+
+The pull request is divided into a four-step review process.
+
+### Step 1:
+* When the contributor creates the pull request, the corresponding CODEOWNERS are automatically assigned and review the pull request. If this process is successfully completed, the CODEOWNERS set the appropriate version bump label: `patch`, `minor`, or `major`.
+
+### Step 2:
+* The necessary version folder structure is then created in the domain. Optionally, the script `create-version-folder.yml` can be used by setting the label `create-version-folder`, which triggers a GitHub action.
+
+### Step 3:
+* The automatic verification of the necessary version folder structure is started by setting the label `check-version-folder`.
+
+### Step 4:
+* Before the pull request is merged into the main branch, the label `create-releases` can be set to automatically generate the domain release. Alternatively, the corresponding release must be manually created by the CODEOWNERS after merging into the main branch.
+
+**Below is a more detailed explanation of the release process:**
+
+### Labels
+
+1. **Version Bump**:
+   - `patch`: Choose this label for small bug fixes or changes that do not add new features. The version number will be incremented by 0.0.1.
+   - `minor`: Choose this label for minor new features or significant improvements that are backward compatible. The version number will be incremented by 0.1.0.
+   - `major`: Choose this label for major changes or new features that may not be backward compatible. The version number will be incremented by 1.0.0.
+
+2. **Optional**:
+   - `create-version-folder`: Choose this label when the GitHub action should create the necessary code subfolder structure.
+   - `create-release`: Choose this label if an automated release should be generated after merging the pull request.
+
+3. **Check**:
+   - `check-version-folder`: Choose this label to trigger the check for the version subfolder.
+
+### Subfolder Structure
+
+For each domain in the main branch (e.g., `domain1`, `domain2`, etc.), a new version subfolder must be created depending on the amount of changes and the assigned category, which is defined by the three labels: patch, minor, and major. For the patch label, the version number is incremented by `v[].[].[+1]`. For the minor label, the version number is incremented by `v[].[+1].[]`. For the major label, the version number is incremented by `v[+1].[].[]`. The structure should look like this:
+
+```
+repository-root/
+├── domain1/
+│   ├── v1.0.0/
+│   │   ├── file1_shacl.ttl
+│   │   ├── file1_ontology.ttl
+│   │   └── file1_instance.json
+│   ├── v1.1.0/
+│   │   ├── file1_shacl.ttl
+│   │   ├── file1_ontology.ttl
+│   │   └── file1_instance.json
+│   ├── file1_shacl.ttl
+│   ├── file1_ontology.ttl
+│   ├── file1_instance.json
+│   └── ...
+├── domain2/
+│   ├── v1.0.0/
+│   │   ├── file2_shacl.ttl
+│   │   ├── file2_ontology.ttl
+│   │   └── file2_instance.json
+│   ├── v1.1.0/
+│   │   ├── file2_shacl.ttl
+│   │   ├── file2_ontology.ttl
+│   │   └── file2_instance.json
+│   ├── file2_shacl.ttl
+│   ├── file2_ontology.ttl
+│   ├── file2_instance.json
+│   └── ...
+└── ...
+```
+
+### Update files
+
+   - Open the `.ttl` and `.json` files in the new version subfolder and update the `@prefix` and `@context` entries to reflect the new version URIs.
+
+   ```ttl
+   @prefix example: <https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/domain1/v1.0.0/> .
+   ```
+
+   ```json
+   {
+     "@context": {
+       "domain1": "https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/domain1/v1.0.0/"
+     }
+   }
+   ```
+
+### Subfolder Checker
+
+To ensure that the subfolders are correctly created, a separate GitHub Actions workflow is used. This workflow is triggered when the label `check-version-folder` is added to the pull request.
+
 ## CI pipeline
 
 The CI/CD pipeline is defined in the `.github/workflows` directory. The pipeline is triggered on every push to the repository as defined in the workflow. The result can be seen in the `Actions` tab in the github repository.

--- a/src/check_subfolder_for_release.py
+++ b/src/check_subfolder_for_release.py
@@ -1,0 +1,140 @@
+import os
+import re
+import json
+import subprocess
+
+# Funktion, um den neuesten Tag eines Subfolders zu erhalten
+def get_latest_tag(subfolder):
+    result = subprocess.run(
+        ["git", "ls-remote", "--tags", "origin"],
+        capture_output=True,
+        text=True
+    )
+    tags = result.stdout.splitlines()
+    latest_tag = ""
+    for tag in tags:
+        if f"refs/tags/{subfolder}_v" in tag:
+            tag_name = re.search(f"{subfolder}_v[0-9]*\\.[0-9]*\\.[0-9]*$", tag)
+            if tag_name:
+                latest_tag = tag_name.group(0)
+    return latest_tag
+
+# Funktion, um zu überprüfen, ob der Versionsordner und die erforderlichen Dateien existieren
+def check_version_subfolder(subfolder, version):
+    version_folder = f"v{version}"
+    folder_path = os.path.join(subfolder, version_folder)
+    if not os.path.exists(folder_path):
+        print(f"Error: Version folder {folder_path} does not exist.")
+        return False
+
+    required_files = [f"{subfolder}_shacl.ttl", f"{subfolder}_ontology.ttl", f"{subfolder}_instance.json"]
+    for file in required_files:
+        if not os.path.exists(os.path.join(folder_path, file)):
+            print(f"Error: Required file {file} does not exist in {folder_path}.")
+            return False
+
+    return True
+
+# Funktion, um die TTL-Dateien zu überprüfen
+def check_ttl_files(subfolder, version_folder, subfolders, current_version):
+    ttl_files = [f for f in os.listdir(os.path.join(subfolder, version_folder)) if f.endswith(('_shacl.ttl', '_ontology.ttl'))]
+    for ttl_file in ttl_files:
+        file_path = os.path.join(subfolder, version_folder, ttl_file)
+        with open(file_path, 'r') as file:
+            content = file.readlines()
+        for line in content:
+            if line.startswith('@prefix'):
+                for folder in subfolders:
+                    if folder in line:
+                        if folder == subfolder:
+                            version = current_version
+                        else:
+                            latest_tag = get_latest_tag(folder)
+                            if latest_tag:
+                                version = latest_tag.split('_v')[-1]
+                        expected_uri = re.sub(r'/(v[0-9]+\\.[0-9]+\\.[0-9]+/)?$', f'/v{version}/', f'https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/{folder}/')
+                        if not re.search(f'<{expected_uri}>', line):
+                            print(f"Error: @prefix in {file_path} does not match expected URI {expected_uri}.")
+                            return False
+    return True
+
+# Funktion, um die JSON-Dateien zu überprüfen
+def check_json_files(subfolder, version_folder, subfolders, current_version):
+    json_files = [f for f in os.listdir(os.path.join(subfolder, version_folder)) if f.endswith('_instance.json')]
+    for json_file in json_files:
+        file_path = os.path.join(subfolder, version_folder, json_file)
+        try:
+            with open(file_path, 'r') as file:
+                data = json.load(file)
+            for folder in subfolders:
+                if folder in data.get('@context', {}):
+                    if folder == subfolder:
+                        version = current_version
+                    else:
+                        latest_tag = get_latest_tag(folder)
+                        if latest_tag:
+                            version = latest_tag.split('_v')[-1]
+                    expected_uri = re.sub(r'/(v[0-9]+\\.[0-9]+\\.[0-9]+/)?$', f'/v{version}/', f'https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/{folder}/')
+                    if data['@context'][folder] != expected_uri:
+                        print(f"Error: @context in {file_path} does not match expected URI {expected_uri}.")
+                        return False
+        except json.JSONDecodeError:
+            print(f"Error decoding JSON in {file_path}")
+            return False
+    return True
+
+def main():
+    # Subfolders aus den Umgebungsvariablen abrufen
+    subfolders = os.getenv("subfolders")
+    if subfolders:
+        subfolders = [sf for sf in subfolders.split() if sf != 'gx']
+    else:
+        print("No subfolders found in environment variables.")
+        return
+
+    # Bump-Typ aus den Umgebungsvariablen abrufen
+    bump_type = os.getenv("BUMP_TYPE")
+    if not bump_type:
+        print("No BUMP_TYPE found in environment variables.")
+        return
+    
+    # Geänderte Dateien aus den Umgebungsvariablen abrufen
+    changed_files = os.getenv("files")
+    if changed_files:
+        changed_files = changed_files.split()
+    else:
+        print("No changed files found in environment variables.")
+        return
+
+    # Überprüfen, ob Änderungen in mehreren Subfolders vorgenommen wurden
+    changed_subfolders = set()
+    for subfolder in subfolders:
+        if any(file.startswith(f"{subfolder}/") for file in changed_files):
+            changed_subfolders.add(subfolder)
+    
+    if len(changed_subfolders) > 1:
+        print("Error: Changes span multiple subfolders. Only one subfolder can be modified per pull request.")
+        return
+
+    for subfolder in changed_subfolders:
+        latest_tag = get_latest_tag(subfolder)
+        if latest_tag:
+            latest_version = latest_tag.split('_v')[-1]
+            new_version = bump_version(latest_version, bump_type)
+        else:
+            new_version = "1.0.0"
+        
+        version_folder = f"v{new_version}"
+        if not check_version_subfolder(subfolder, new_version):
+            return
+        
+        if not check_ttl_files(subfolder, version_folder, subfolders, new_version):
+            return
+        
+        if not check_json_files(subfolder, version_folder, subfolders, new_version):
+            return
+
+    print("All checks passed successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/src/create_initial_subfolder.py
+++ b/src/create_initial_subfolder.py
@@ -1,0 +1,95 @@
+import os
+import re
+import json
+import shutil
+import subprocess
+
+def get_latest_tag(subfolder):
+    result = subprocess.run(
+        ["git", "ls-remote", "--tags", "origin"],
+        capture_output=True,
+        text=True
+    )
+    tags = result.stdout.splitlines()
+    latest_tag = ""
+    for tag in tags:
+        if f"refs/tags/{subfolder}_v" in tag:
+            tag_name = re.search(f"{subfolder}_v[0-9]*\\.[0-9]*\\.[0-9]*$", tag)
+            if tag_name:
+                latest_tag = tag_name.group(0)
+    return latest_tag
+
+def create_initial_subfolder(subfolder):
+    latest_tag = get_latest_tag(subfolder)
+    if not latest_tag:
+        # Create initial tag if no tags found
+        initial_version = "v1.0.0"
+        initial_tag = f"{subfolder}_{initial_version}"
+        subprocess.run(["git", "tag", initial_tag])
+        subprocess.run(["git", "push", "origin", initial_tag])
+        latest_tag = initial_tag
+
+    latest_version = latest_tag.split('_v')[-1]
+    clean_version = re.sub(r'[^0-9\\.]', '', latest_version)
+    version_folder = f"v{clean_version}"
+
+    os.makedirs(os.path.join(subfolder, version_folder), exist_ok=True)
+    print(f"Created directory: {os.path.join(subfolder, version_folder)}")
+
+    # Copy only the relevant files to the new version directory
+    for file in os.listdir(subfolder):
+        if file.endswith(('_shacl.ttl', '_ontology.ttl', '_instance.json')):
+            shutil.copy(os.path.join(subfolder, file), os.path.join(subfolder, version_folder))
+            print(f"Copied {file} to {os.path.join(subfolder, version_folder)}")
+
+def update_ttl_files(subfolder, version_folder, subfolders):
+    ttl_files = [f for f in os.listdir(os.path.join(subfolder, version_folder)) if f.endswith(('_shacl.ttl', '_ontology.ttl'))]
+    for ttl_file in ttl_files:
+        file_path = os.path.join(subfolder, version_folder, ttl_file)
+        with open(file_path, 'r') as file:
+            content = file.readlines()
+        with open(file_path, 'w') as file:
+            for line in content:
+                if line.startswith('@prefix'):
+                    for folder in subfolders:
+                        if folder in line:
+                            latest_tag = get_latest_tag(folder)
+                            if latest_tag:
+                                version = latest_tag.split('_v')[-1]
+                                new_uri = re.sub(r'/(v[0-9]+\\.[0-9]+\\.[0-9]+/)?$', f'/v{version}/', f'https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/{folder}/')
+                                line = re.sub(r'<.*>', f'<{new_uri}>', line)
+                file.write(line)
+        print(f"Updated @prefix in {file_path}")
+
+def update_json_files(subfolder, version_folder, subfolders):
+    json_files = [f for f in os.listdir(os.path.join(subfolder, version_folder)) if f.endswith('_instance.json')]
+    for json_file in json_files:
+        file_path = os.path.join(subfolder, version_folder, json_file)
+        with open(file_path, 'r') as file:
+            data = json.load(file)
+        for folder in subfolders:
+            if folder in data.get('@context', {}):
+                latest_tag = get_latest_tag(folder)
+                if latest_tag:
+                    version = latest_tag.split('_v')[-1]
+                    data['@context'][folder] = re.sub(r'/(v[0-9]+\\.[0-9]+\\.[0-9]+/)?$', f'/v{version}/', f'https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/{folder}/')
+        with open(file_path, 'w') as file:
+            json.dump(data, file, indent=2)
+        print(f"Updated @context in {file_path}")
+
+def main():
+    with open('subfolders.txt', 'r') as file:
+        subfolders = [line.strip() for line in file if line.strip() and line.strip() != 'gx']
+    
+    for subfolder in subfolders:
+        create_initial_subfolder(subfolder)
+
+    for subfolder in subfolders:
+        latest_tag = get_latest_tag(subfolder)
+        if latest_tag:
+            version_folder = f"v{latest_tag.split('_v')[-1]}"
+            update_ttl_files(subfolder, version_folder, subfolders)
+            update_json_files(subfolder, version_folder, subfolders)
+
+if __name__ == "__main__":
+    main()

--- a/src/create_subfolder.py
+++ b/src/create_subfolder.py
@@ -1,0 +1,138 @@
+import os
+import re
+import json
+import shutil
+import subprocess
+
+def get_latest_tag(subfolder):
+    result = subprocess.run(
+        ["git", "ls-remote", "--tags", "origin"],
+        capture_output=True,
+        text=True
+    )
+    tags = result.stdout.splitlines()
+    latest_tag = ""
+    for tag in tags:
+        if f"refs/tags/{subfolder}_v" in tag:
+            tag_name = re.search(f"{subfolder}_v[0-9]*\\.[0-9]*\\.[0-9]*$", tag)
+            if tag_name:
+                latest_tag = tag_name.group(0)
+    return latest_tag
+
+def bump_version(version, bump_type):
+    major, minor, patch = map(int, version.split('.'))
+    if bump_type == "major":
+        major += 1
+        minor = 0
+        patch = 0
+    elif bump_type == "minor":
+        minor += 1
+        patch = 0
+    elif bump_type == "patch":
+        patch += 1
+    return f"{major}.{minor}.{patch}"
+
+def create_version_subfolder(subfolder, bump_type):
+    latest_tag = get_latest_tag(subfolder)
+    if latest_tag:
+        latest_version = latest_tag.split('_v')[-1]
+        new_version = bump_version(latest_version, bump_type)
+    else:
+        new_version = "1.0.0"
+    
+    new_tag = f"{subfolder}_v{new_version}"
+    version_folder = f"v{new_version}"
+
+    if not os.path.exists(os.path.join(subfolder, version_folder)):
+        os.makedirs(os.path.join(subfolder, version_folder), exist_ok=True)
+        print(f"Created directory: {os.path.join(subfolder, version_folder)}")
+
+        # Copy only the relevant files to the new version directory
+        for file in os.listdir(subfolder):
+            if file.endswith(('_shacl.ttl', '_ontology.ttl', '_instance.json')):
+                shutil.copy(os.path.join(subfolder, file), os.path.join(subfolder, version_folder))
+                print(f"Copied {file} to {os.path.join(subfolder, version_folder)}")
+
+    return new_tag, version_folder, new_version
+
+def update_ttl_files(subfolder, version_folder, subfolders, current_version):
+    ttl_files = [f for f in os.listdir(os.path.join(subfolder, version_folder)) if f.endswith(('_shacl.ttl', '_ontology.ttl'))]
+    for ttl_file in ttl_files:
+        file_path = os.path.join(subfolder, version_folder, ttl_file)
+        with open(file_path, 'r') as file:
+            content = file.readlines()
+        with open(file_path, 'w') as file:
+            for line in content:
+                if line.startswith('@prefix'):
+                    for folder in subfolders:
+                        if folder in line:
+                            if folder == subfolder:
+                                version = current_version
+                            else:
+                                latest_tag = get_latest_tag(folder)
+                                if latest_tag:
+                                    version = latest_tag.split('_v')[-1]
+                            new_uri = re.sub(r'/(v[0-9]+\\.[0-9]+\\.[0-9]+/)?$', f'/v{version}/', f'https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/{folder}/')
+                            line = re.sub(r'<.*>', f'<{new_uri}>', line)
+                file.write(line)
+        print(f"Updated @prefix in {file_path}")
+
+def update_json_files(subfolder, version_folder, subfolders, current_version):
+    json_files = [f for f in os.listdir(os.path.join(subfolder, version_folder)) if f.endswith('_instance.json')]
+    for json_file in json_files:
+        file_path = os.path.join(subfolder, version_folder, json_file)
+        try:
+            with open(file_path, 'r') as file:
+                data = json.load(file)
+            for folder in subfolders:
+                if folder in data.get('@context', {}):
+                    if folder == subfolder:
+                        version = current_version
+                    else:
+                        latest_tag = get_latest_tag(folder)
+                        if latest_tag:
+                            version = latest_tag.split('_v')[-1]
+                    data['@context'][folder] = re.sub(r'/(v[0-9]+\\.[0-9]+\\.[0-9]+/)?$', f'/v{version}/', f'https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/{folder}/')
+            with open(file_path, 'w') as file:
+                json.dump(data, file, indent=2)
+            print(f"Updated @context in {file_path}")
+        except json.JSONDecodeError:
+            print(f"Error decoding JSON in {file_path}")
+
+def save_versions(versions):
+    with open("versions.txt", "w") as file:
+        for version in versions:
+            file.write(f"{version[0]} {version[1]} {version[2]}\n")
+
+def main():
+    subfolders = os.getenv("subfolders")
+    if subfolders:
+        subfolders = [sf for sf in subfolders.split() if sf != 'gx']
+    else:
+        print("No subfolders found in environment variables.")
+        return
+
+    bump_type = os.getenv("BUMP_TYPE")
+    if not bump_type:
+        print("No BUMP_TYPE found in environment variables.")
+        return
+    
+    changed_files = os.getenv("files")
+    if changed_files:
+        changed_files = changed_files.split()
+    else:
+        print("No changed files found in environment variables.")
+        return
+
+    versions = []
+    for subfolder in subfolders:
+        if any(file.startswith(f"{subfolder}/") for file in changed_files):
+            new_tag, version_folder, new_version = create_version_subfolder(subfolder, bump_type)
+            update_ttl_files(subfolder, version_folder, subfolders, new_version)
+            update_json_files(subfolder, version_folder, subfolders, new_version)
+            versions.append((subfolder, new_tag, version_folder))
+    
+    save_versions(versions)
+
+if __name__ == "__main__":
+    main()

--- a/src/release_folder.py
+++ b/src/release_folder.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+
+# Funktion, um den neuesten Tag eines Subfolders zu erhalten
+def get_latest_tag(folder):
+    result = subprocess.run(
+        ["git", "tag", "-l", f"{folder}_v*"],
+        capture_output=True,
+        text=True
+    )
+    tags = result.stdout.strip().split("\n")
+    tags.sort()
+    return tags[-1] if tags else None
+
+# Funktion, um einen Versionsordner zu erstellen und ein Release zu erzeugen
+def create_version_subfolder(subfolder, new_tag, version_folder):
+    os.makedirs(os.path.join(subfolder, version_folder), exist_ok=True)
+    print(f"Created directory: {os.path.join(subfolder, version_folder)}")
+
+    os.chdir(subfolder)
+    subprocess.run(["git", "tag", "-a", new_tag, "-m", f"Release for {subfolder} version {new_tag.split('_v')[-1]}"])
+    subprocess.run(["git", "push", "origin", new_tag])
+    subprocess.run(["zip", "-r", f"{subfolder}_{new_tag.split('_v')[-1]}.zip", version_folder])
+    subprocess.run(["gh", "release", "create", new_tag, f"{subfolder}_{new_tag.split('_v')[-1]}.zip", "--title", new_tag, "--notes", f"Automated release for {subfolder} version {new_tag.split('_v')[-1]}"])
+    os.chdir("..")
+
+def main():
+    if not os.path.exists("versions.txt"):
+        print("No versions.txt file found.")
+        return
+
+    with open("versions.txt", "r") as file:
+        versions = [line.strip().split() for line in file.readlines()]
+
+    for subfolder, new_tag, version_folder in versions:
+        create_version_subfolder(subfolder, new_tag, version_folder)
+
+if __name__ == "__main__":
+    main()

--- a/src/update_prefixes.py
+++ b/src/update_prefixes.py
@@ -1,0 +1,95 @@
+import os
+import re
+import json
+import shutil
+import subprocess
+
+def get_latest_tag(subfolder):
+    result = subprocess.run(
+        ["git", "ls-remote", "--tags", "origin"],
+        capture_output=True,
+        text=True
+    )
+    tags = result.stdout.splitlines()
+    latest_tag = ""
+    for tag in tags:
+        if f"refs/tags/{subfolder}_v" in tag:
+            tag_name = re.search(f"{subfolder}_v[0-9]*\\.[0-9]*\\.[0-9]*$", tag)
+            if tag_name:
+                latest_tag = tag_name.group(0)
+    return latest_tag
+
+def create_initial_subfolder(subfolder):
+    latest_tag = get_latest_tag(subfolder)
+    if not latest_tag:
+        # Create initial tag if no tags found
+        initial_version = "v1.0.0"
+        initial_tag = f"{subfolder}_{initial_version}"
+        subprocess.run(["git", "tag", initial_tag])
+        subprocess.run(["git", "push", "origin", initial_tag])
+        latest_tag = initial_tag
+
+    latest_version = latest_tag.split('_v')[-1]
+    clean_version = re.sub(r'[^0-9\\.]', '', latest_version)
+    version_folder = f"v{clean_version}"
+
+    os.makedirs(os.path.join(subfolder, version_folder), exist_ok=True)
+    print(f"Created directory: {os.path.join(subfolder, version_folder)}")
+
+    # Copy only the relevant files to the new version directory
+    for file in os.listdir(subfolder):
+        if file.endswith(('_shacl.ttl', '_ontology.ttl', '_instance.json')):
+            shutil.copy(os.path.join(subfolder, file), os.path.join(subfolder, version_folder))
+            print(f"Copied {file} to {os.path.join(subfolder, version_folder)}")
+
+def update_ttl_files(subfolder, version_folder, subfolders):
+    ttl_files = [f for f in os.listdir(os.path.join(subfolder, version_folder)) if f.endswith(('_shacl.ttl', '_ontology.ttl'))]
+    for ttl_file in ttl_files:
+        file_path = os.path.join(subfolder, version_folder, ttl_file)
+        with open(file_path, 'r') as file:
+            content = file.readlines()
+        with open(file_path, 'w') as file:
+            for line in content:
+                if line.startswith('@prefix'):
+                    for folder in subfolders:
+                        if folder in line:
+                            latest_tag = get_latest_tag(folder)
+                            if latest_tag:
+                                version = latest_tag.split('_v')[-1]
+                                new_uri = re.sub(r'/(v[0-9]+\\.[0-9]+\\.[0-9]+/)?$', f'/v{version}/', f'https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/{folder}/')
+                                line = re.sub(r'<.*>', f'<{new_uri}>', line)
+                file.write(line)
+        print(f"Updated @prefix in {file_path}")
+
+def update_json_files(subfolder, version_folder, subfolders):
+    json_files = [f for f in os.listdir(os.path.join(subfolder, version_folder)) if f.endswith('_instance.json')]
+    for json_file in json_files:
+        file_path = os.path.join(subfolder, version_folder, json_file)
+        with open(file_path, 'r') as file:
+            data = json.load(file)
+        for folder in subfolders:
+            if folder in data.get('@context', {}):
+                latest_tag = get_latest_tag(folder)
+                if latest_tag:
+                    version = latest_tag.split('_v')[-1]
+                    data['@context'][folder] = re.sub(r'/(v[0-9]+\\.[0-9]+\\.[0-9]+/)?$', f'/v{version}/', f'https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/main/{folder}/')
+        with open(file_path, 'w') as file:
+            json.dump(data, file, indent=2)
+        print(f"Updated @context in {file_path}")
+
+def main():
+    with open('subfolders.txt', 'r') as file:
+        subfolders = [line.strip() for line in file if line.strip() and line.strip() != 'gx']
+    
+    for subfolder in subfolders:
+        create_initial_subfolder(subfolder)
+
+    for subfolder in subfolders:
+        latest_tag = get_latest_tag(subfolder)
+        if latest_tag:
+            version_folder = f"v{latest_tag.split('_v')[-1]}"
+            update_ttl_files(subfolder, version_folder, subfolders)
+            update_json_files(subfolder, version_folder, subfolders)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

This pull request adds a release management frame work to the repo. 

This gives the contributors and reviewers enough flexibility to complete the requested process manually or to trigger existing scripts by setting labels, resulting in semi-automation.

You can find more information about the process here:
https://github.com/GAIA-X4PLC-AAD/ontology-management-base/tree/release-management?tab=readme-ov-file#release-management

**Note:**
It is recommended to start the script `create-initial-subfolders-and-releases.yml` manually under action after merge this pullrequest into main. This will create a release with version 1.0.0 for each existing domain in main.


## How Has This Been Tested?

The release management framework was tested in a separate repo and can also be tested by the reviewers here: 

## Checklist

- [ ] My code follows the modelling guidelines of this project
- [ ] I have performed a self-review of my own changes
