### PR TITLE
149 vv report add user parameters

### DIFF
--- a/envited-x/PROPERTIES.md
+++ b/envited-x/PROPERTIES.md
@@ -30,5 +30,5 @@
 | DataResourceExtensionShape | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
 | DataResourceExtensionShape | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |
 | DataResourceExtensionShape | envited-x | hasDataResourceExtension |  |  |  |  | envited-x_shacl.ttl |
-| nef52f8f6b1ad47a6b60786e1efc02a9fb73 | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
-| nef52f8f6b1ad47a6b60786e1efc02a9fb73 | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |
+| n98e114eda21f4182973d953b8e0fdff5b73 | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
+| n98e114eda21f4182973d953b8e0fdff5b73 | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |

--- a/envited-x/PROPERTIES.md
+++ b/envited-x/PROPERTIES.md
@@ -30,5 +30,5 @@
 | DataResourceExtensionShape | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
 | DataResourceExtensionShape | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |
 | DataResourceExtensionShape | envited-x | hasDataResourceExtension |  |  |  |  | envited-x_shacl.ttl |
-| n98e114eda21f4182973d953b8e0fdff5b73 | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
-| n98e114eda21f4182973d953b8e0fdff5b73 | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |
+| n256f71dca20f479287e6266bf75e831cb73 | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
+| n256f71dca20f479287e6266bf75e831cb73 | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |

--- a/envited-x/PROPERTIES.md
+++ b/envited-x/PROPERTIES.md
@@ -30,5 +30,5 @@
 | DataResourceExtensionShape | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
 | DataResourceExtensionShape | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |
 | DataResourceExtensionShape | envited-x | hasDataResourceExtension |  |  |  |  | envited-x_shacl.ttl |
-| n256f71dca20f479287e6266bf75e831cb73 | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
-| n256f71dca20f479287e6266bf75e831cb73 | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |
+| nbc1f7a4ef8e74d0681a15d01a52109e5b73 | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
+| nbc1f7a4ef8e74d0681a15d01a52109e5b73 | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |

--- a/vv-report/PROPERTIES.md
+++ b/vv-report/PROPERTIES.md
@@ -13,6 +13,7 @@
 | VvReportShape | vv-report | evaluations | 1 |  | A list of all measures carried out on the subject under test. |  | vv-report_shacl.ttl |
 | EvaluationShape | vv-report | metric | 1 | 1 | The definition of the quality metric that has been used in this evaluation item. |  | vv-report_shacl.ttl |
 | EvaluationShape | vv-report | inputData | 1 |  | The definition of a dataset that has been used as input to the quality metric. |  | vv-report_shacl.ttl |
+| EvaluationShape | vv-report | parameters | 0 |  | A list of parameters that have been used to configure the quality metric and/or quality criterion. |  | vv-report_shacl.ttl |
 | EvaluationShape | vv-report | result | 1 | 1 | The summary of the result of this evaluation item. |  | vv-report_shacl.ttl |
 | EvaluationShape | vv-report | conceptSpecificData | 0 |  | Additional arbitrary V&V-concept specific data, to further describe the evaluation. |  | vv-report_shacl.ttl |
 | MetricShape | vv-report | metricTitle | 1 | 1 | A meaningful name of this metric. | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
@@ -20,9 +21,12 @@
 | MetricShape | vv-report | metricReference | 1 | 1 | Uniform Resource Identifier (URI) to identify the metric by location, name, or both. | <http://www.w3.org/2001/XMLSchema#anyURI> | vv-report_shacl.ttl |
 | InputDataShape | vv-report | inputDescription | 1 | 1 | A short description for interpreting this input data element | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
 | InputDataShape | vv-report | inputReference | 1 | 1 | Uniform Resource Identifier (URI) to identify the utilized input data element by location, name, or both. | <http://www.w3.org/2001/XMLSchema#anyURI> | vv-report_shacl.ttl |
+| ParameterShape | vv-report | parameterName | 1 | 1 | The formal name of the parameter, as it appears in the validation system | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
+| ParameterShape | vv-report | parameterDescription | 1 | 1 | A short description of the parameter in order to unambigously interpret it. | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
+| ParameterShape | vv-report | parameterValue | 1 | 1 | The value of the parameter. | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
 | ResultShape | vv-report | resultTestPassed | 1 | 1 | Statement if the test has been passed or not. | <http://www.w3.org/2001/XMLSchema#boolean> | vv-report_shacl.ttl |
 | ResultShape | vv-report | resultLog | 0 |  | Additional information about the test result, e.g., why it has failed. | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
 | ResultShape | vv-report | resultVerifiable | 1 | 1 | Information if the result can be verified by a third party. | <http://www.w3.org/2001/XMLSchema#boolean> | vv-report_shacl.ttl |
 | ResultShape | vv-report | resultVerification | 0 | 1 | The necessary attributes to carry out verification of the result by a third party. |  | vv-report_shacl.ttl |
-| ResultVerificationShape | vv-report | resultVerificationDescription | 1 | 1 | A short description of how the result can be verified with the given reference. |  | vv-report_shacl.ttl |
+| ResultVerificationShape | vv-report | resultVerificationDescription | 1 | 1 | A short description of how the result can be verified with the given reference. | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
 | ResultVerificationShape | vv-report | resultVerificationReference | 1 |  | Uniform Resource Identifier (URI) to identify the reference used to verify the result of this evalation by location, name, or both. | <http://www.w3.org/2001/XMLSchema#anyURI> | vv-report_shacl.ttl |

--- a/vv-report/PROPERTIES.md
+++ b/vv-report/PROPERTIES.md
@@ -23,7 +23,7 @@
 | InputDataShape | vv-report | inputReference | 1 | 1 | Uniform Resource Identifier (URI) to identify the utilized input data element by location, name, or both. | <http://www.w3.org/2001/XMLSchema#anyURI> | vv-report_shacl.ttl |
 | ParameterShape | vv-report | parameterName | 1 | 1 | The formal name of the parameter, as it appears in the validation system | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
 | ParameterShape | vv-report | parameterDescription | 1 | 1 | A short description of the parameter in order to unambigously interpret it. | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
-| ParameterShape | vv-report | parameterValue | 1 | 1 | The value of the parameter. | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
+| ParameterShape | vv-report | parameterValue | 1 | 1 | The value of the parameter. |  | vv-report_shacl.ttl |
 | ResultShape | vv-report | resultTestPassed | 1 | 1 | Statement if the test has been passed or not. | <http://www.w3.org/2001/XMLSchema#boolean> | vv-report_shacl.ttl |
 | ResultShape | vv-report | resultLog | 0 |  | Additional information about the test result, e.g., why it has failed. | <http://www.w3.org/2001/XMLSchema#string> | vv-report_shacl.ttl |
 | ResultShape | vv-report | resultVerifiable | 1 | 1 | Information if the result can be verified by a third party. | <http://www.w3.org/2001/XMLSchema#boolean> | vv-report_shacl.ttl |

--- a/vv-report/vv-report_instance.json
+++ b/vv-report/vv-report_instance.json
@@ -40,7 +40,7 @@
             "vv-report:metric": {
                 "@type": "vv-report:Metric",
                 "vv-report:metricTitle": {
-                    "@value": "Model ouput OSI validation",
+                    "@value": "Model output OSI validation",
                     "@type": "xsd:string"
                 },
                 "vv-report:metricDescription": {
@@ -76,6 +76,23 @@
                     }
                 }
             ],
+            "vv-report:parameters": [
+                {
+                    "@type": "vv-report:Parameter",
+                    "vv-report:parameterName": {
+                        "@value": "verbose",
+                        "@type": "xsd:string"
+                    },
+                    "vv-report:parameterDescription": {
+                        "@value": "If set to true, extensive checks, according to XY, will be carried out",
+                        "@type": "xsd:string"
+                    },
+                    "vv-report:parameterValue": {
+                        "@value": false,
+                        "@type": "xsd:boolean"
+                    }
+                }
+            ],
             "vv-report:result": {
                 "@type": "vv-report:Result",
                 "vv-report:resultTestPassed": {
@@ -87,7 +104,7 @@
                     "@type": "xsd:boolean"
                 }
             },
-            "vv-report:metadata": {
+            "vv-report:conceptSpecificData": {
                 "modeling-simulation-spice-credibility-level": {
                     "@value": 1,
                     "@type": "xsd:integer"
@@ -150,7 +167,7 @@
                     }
                 }
             },
-            "vv-report:metadata": {
+            "vv-report:conceptSpecificData": {
                 "modeling-simulation-spice-credibility-level": {
                     "@value": 1,
                     "@type": "xsd:integer"

--- a/vv-report/vv-report_ontology.ttl
+++ b/vv-report/vv-report_ontology.ttl
@@ -59,6 +59,10 @@ vv-report:InputData a owl:Class ;
     rdfs:label "Class definition for InputData"@en ;
     rdfs:comment "Attributes for the definition of an input data element of a verification & validation report."@en .
 
+vv-report:Parameter a owl:Class ;
+    rdfs:label "Class definition for Parameter"@en ;
+    rdfs:comment "Attributes for the definition of parameter element of a verification & validation report."@en .
+
 vv-report:Result a owl:Class ;
     rdfs:label "Class definition for Result"@en ;
     rdfs:comment "Attributes for evaluation results of a verification & validation report."@en .

--- a/vv-report/vv-report_shacl.ttl
+++ b/vv-report/vv-report_shacl.ttl
@@ -41,6 +41,10 @@ vv-report:EvaluationShape a sh:NodeShape ;
             sh:description "The definition of a dataset that has been used as input to the quality metric."@en ;
             sh:minCount 1 ;
             sh:order 1 ],
+        [ sh:path vv-report:parameters ;
+            sh:node general:ParameterShape ;
+            sh:description "A list of parameters that have been used to configure the quality metric and/or quality criterion."@en ;
+            sh:minCount 0 ],
         [ sh:path vv-report:result ;
             sh:node vv-report:ResultShape ;
             sh:description "The summary of the result of this evaluation item."@en ;
@@ -98,6 +102,41 @@ vv-report:InputDataShape a sh:NodeShape ;
             sh:order 1 ] ;
     sh:targetClass vv-report:InputData .
 
+vv-report:ParameterShape a sh:NodeShape ;
+    sh:property [ skos:example "max_allowed_deviation"@en ;
+            sh:path vv-report:parameterName ;
+            sh:name "parameter name"@en ;
+            sh:description "The formal name of the parameter, as it appears in the validation system"@en ;
+            sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:order 0 ],
+        [ skos:example "Maximum allowed position deviation in meters, to pass the test."@en ; 
+            sh:path vv-report:parameterDescription ;
+            sh:name "parameter description"@en ;
+            sh:description "A short description of the parameter in order to unambigously interpret it."@en ;
+            sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:order 1 ],
+        [ skos:example "0.19" ;
+            sh:path vv-report:parameterValue ;
+            sh:name "parameter value"@en ;
+            sh:description "The value of the parameter."@en ;
+            sh:datatype xsd:string ;
+            sh:or (
+                [ sh:datatype xsd:string ]
+                [ sh:datatype xsd:boolean ]
+                [ sh:datatype xsd:integer ]
+                [ sh:datatype xsd:decimal ]
+                [ sh:datatype xsd:float ]
+                [ sh:datatype xsd:double ]
+            ) ;
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:order 2 ] ;
+    sh:targetClass vv-report:Parameter .
+
 vv-report:ResultShape a sh:NodeShape ;
     sh:property [ skos:example "false" ;
             sh:path vv-report:resultTestPassed ;
@@ -132,6 +171,7 @@ vv-report:ResultVerificationShape a sh:NodeShape ;
             sh:path vv-report:resultVerificationDescription ;
             sh:name "verification method description"@en ;
             sh:description "A short description of how the result can be verified with the given reference."@en ;
+            sh:datatype xsd:string ;
             sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:order 0 ],

--- a/vv-report/vv-report_shacl.ttl
+++ b/vv-report/vv-report_shacl.ttl
@@ -123,7 +123,6 @@ vv-report:ParameterShape a sh:NodeShape ;
             sh:path vv-report:parameterValue ;
             sh:name "parameter value"@en ;
             sh:description "The value of the parameter."@en ;
-            sh:datatype xsd:string ;
             sh:or (
                 [ sh:datatype xsd:string ]
                 [ sh:datatype xsd:boolean ]


### PR DESCRIPTION
# Description

Adding a section to include utilized parameters to specifically configure a validation metric (e.g. adding a threshold as quality criterion)

## Type of change

Please delete options that are not relevant.

- [ ] New type (non-breaking change which adds a type)
- [x] Change (non-breaking change or fix on an existing type)
- [ ] Breaking change (Change that would cause existing Self Descriptions not to be accepted anymore by a Federated Catalogue)

## How Has This Been Tested?

Actions pipeline

## Checklist

- [x] My code follows the modelling guidelines of this project
- [x] I have performed a self-review of my own changes
