### PR TITLE
Fixes for asset extractor

### DIFF
--- a/envited-x/PROPERTIES.md
+++ b/envited-x/PROPERTIES.md
@@ -30,5 +30,5 @@
 | DataResourceExtensionShape | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
 | DataResourceExtensionShape | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |
 | DataResourceExtensionShape | envited-x | hasDataResourceExtension |  |  |  |  | envited-x_shacl.ttl |
-| n822229e26e984ae0972ca05dcdb2f31db73 | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
-| n822229e26e984ae0972ca05dcdb2f31db73 | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |
+| n6939b8777e53473f967a18e00027cf51b73 | envited-x | hasContent | 1 |  |  |  | envited-x_shacl.ttl |
+| n6939b8777e53473f967a18e00027cf51b73 | envited-x | hasFormat | 1 |  |  |  | envited-x_shacl.ttl |

--- a/envited-x/envited-x_shacl.ttl
+++ b/envited-x/envited-x_shacl.ttl
@@ -49,11 +49,13 @@ envited-x:SimulationAssetShape a sh:NodeShape ;
 
 envited-x:ExtendedLinkShape a sh:NodeShape ;
   sh:property [
+    sh:name manifest:AccessRole ;
     sh:path manifest:hasAccessRole ;
     sh:in ( envited-x:isPublic envited-x:isOwner envited-x:isRegistered ) ;
     sh:message "Access role must be one of the envited‑x defined access roles." ;
   ] ;
   sh:property [
+    sh:name manifest:Category ;
     sh:path manifest:hasCategory ;
     sh:in (
       envited-x:isManifest
@@ -87,6 +89,7 @@ envited-x:ManifestShape a sh:NodeShape ;
             ] ;
         ] ;
         sh:qualifiedMinCount 1 ;
+        sh:qualifiedMaxCount 1 ;
         sh:message "An envited-x manifest must contain at least one manifest reference link with an envited-x access role and category."@en ;
     ] ;
     sh:property [
@@ -105,6 +108,7 @@ envited-x:ManifestShape a sh:NodeShape ;
             ]
         ] ;
         sh:qualifiedMinCount 1 ;
+        sh:qualifiedMaxCount 1 ;
         sh:message "An envited-x manifest must contain at least one license link with an envited-x access role and category."@en ;
     ] ;
     


### PR DESCRIPTION
# Description

changes are required so that jsonLDs can be generated automatically from the shacls for https://github.com/GAIA-X4PLC-AAD/provider-tools/tree/main/asset_extraction.

## Type of change

Please delete options that are not relevant.

- [ ] New type (non-breaking change which adds a type)
- [x] Change (non-breaking change or fix on an existing type)
- [ ] Breaking change (Change that would cause existing Self Descriptions not to be accepted anymore by a Federated Catalogue)


## Changes in envited-x.ttl

- ExtendedLinkShape: 
add names for properies AccessRole and Category

- ManifestShape
add sh:qualifiedMaxCount 1 for properties hasManifestReference and hasLicense (Otherwise the entries would have to be kept as lists)

## Checklist

- [x] My code follows the modelling guidelines of this project
- [x] I have performed a self-review of my own changes
